### PR TITLE
Implement live preview and settings dialog

### DIFF
--- a/pictocode/ui/app_settings_dialog.py
+++ b/pictocode/ui/app_settings_dialog.py
@@ -1,0 +1,28 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QComboBox, QDialogButtonBox
+from PyQt5.QtCore import Qt
+
+class AppSettingsDialog(QDialog):
+    """Dialog to adjust global application settings like appearance."""
+    def __init__(self, current_theme: str = "Light", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Param\u00e8tres de l'application")
+        self.setModal(True)
+
+        main_layout = QVBoxLayout(self)
+        form = QFormLayout()
+        main_layout.addLayout(form)
+
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItems(["Light", "Dark"])
+        idx = self.theme_combo.findText(current_theme)
+        if idx >= 0:
+            self.theme_combo.setCurrentIndex(idx)
+        form.addRow("Th\u00e8me :", self.theme_combo)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        main_layout.addWidget(buttons)
+
+    def get_theme(self) -> str:
+        return self.theme_combo.currentText()

--- a/pictocode/ui/toolbar.py
+++ b/pictocode/ui/toolbar.py
@@ -21,6 +21,11 @@ class Toolbar(QToolBar):
         line_act.triggered.connect(lambda: self.canvas.set_tool("line"))
         self.addAction(line_act)
 
+        # Tracé libre
+        free_act = QAction("Tracer libre", self)
+        free_act.triggered.connect(lambda: self.canvas.set_tool("freehand"))
+        self.addAction(free_act)
+
         # Texte
         text_act = QAction("Texte", self)
         text_act.triggered.connect(lambda: self.canvas.set_tool("text"))

--- a/pictocode/utils.py
+++ b/pictocode/utils.py
@@ -24,3 +24,20 @@ def generate_pycode(shapes):
             lines.append(f'scene.addItem(rect{i})')
             lines.append('')
     return '\n'.join(lines)
+
+# ---------------------------------------------------------------------------
+def to_pixels(value: float, unit: str, dpi: float = 72) -> float:
+    """Convertit une longueur dans l'unité donnée vers des pixels."""
+    unit = unit.lower()
+    if unit == 'px':
+        return float(value)
+    if unit == 'pt':
+        return float(value) * dpi / 72.0
+    if unit == 'mm':
+        return float(value) * dpi / 25.4
+    if unit == 'cm':
+        return float(value) * dpi / 2.54
+    if unit == 'in':
+        return float(value) * dpi
+    return float(value)
+


### PR DESCRIPTION
## Summary
- enable live drawing preview for shapes and freehand tool
- mark project dirty on canvas changes
- add application settings dialog for appearance
- support light/dark themes with persistent choice

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850aa2fa06c832394dcf3597211a0b4