### PR TITLE
Fix import path in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 # pictocode/__main__.py
 import sys
 from PyQt5.QtWidgets import QApplication
-from .ui.main_window import MainWindow
+from pictocode.ui.main_window import MainWindow
 
 def main():
     app = QApplication(sys.argv)


### PR DESCRIPTION
## Summary
- fix MainWindow import path for running main.py directly

## Testing
- `python main.py` *(fails: Qt platform plugin "xcb" could not be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_685128ab2a548323930081f10a364670