### PR TITLE
Fix Projects directory path relative to UI

### DIFF
--- a/pictocode/ui/home_page.py
+++ b/pictocode/ui/home_page.py
@@ -15,7 +15,7 @@ class HomePage(QWidget):
     - Bouton « Nouveau projet »
     - Double-clic sur un projet pour l’ouvrir
     """
-    PROJECTS_DIR = os.path.join(os.getcwd(), "Projects")
+    PROJECTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Projects")
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -13,7 +13,7 @@ from .inspector import Inspector
 from .home_page import HomePage
 from .new_project_dialog import NewProjectDialog
 
-PROJECTS_DIR = os.path.join(os.getcwd(), "Projects")
+PROJECTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Projects")
 
 class MainWindow(QMainWindow):
     def __init__(self):


### PR DESCRIPTION
## Summary
- locate `PROJECTS_DIR` using the directory of the module instead of `os.getcwd`

## Testing
- `python -m compileall -q pictocode`

------
https://chatgpt.com/codex/tasks/task_e_685128ab89ac832382dcbfd5d800674a