### PR TITLE
Fix encoding for canvas comment

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1,4 +1,5 @@
 # pictocode/canvas.py
+# -*- coding: utf-8 -*-
 
 import math
 from PyQt5.QtWidgets import QGraphicsView, QGraphicsScene, QAction


### PR DESCRIPTION
## Summary
- ensure canvas uses UTF-8 encoding declaration
- the "Scène" comment now displays correctly

## Testing
- `python -m compileall -q pictocode` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_68517afa0114832391a6e8a7f2d74e74