### PR TITLE
Handle more shapes in exports

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -249,16 +249,25 @@ class CanvasWidget(QGraphicsView):
                            stroke=stroke)
             elif cls == 'FreehandPath':
                 path = item.path()
-                cmds = []
-                for i in range(path.elementCount()):
-                    ept = path.elementAt(i)
-                    cmd = 'M' if i == 0 else 'L'
-                    cmds.append(f"{cmd}{ept.x} {ept.y}")
-                SubElement(root, 'path', d=' '.join(cmds), fill='none', stroke=stroke)
+                pts = [path.elementAt(i) for i in range(path.elementCount())]
+                if len(pts) > 2 and pts[0].x == pts[-1].x and pts[0].y == pts[-1].y:
+                    points = ' '.join(f"{p.x},{p.y}" for p in pts[:-1])
+                    SubElement(root, 'polygon', points=points, fill='none', stroke=stroke)
+                else:
+                    cmds = []
+                    for i, ept in enumerate(pts):
+                        cmd = 'M' if i == 0 else 'L'
+                        cmds.append(f"{cmd}{ept.x} {ept.y}")
+                    SubElement(root, 'path', d=' '.join(cmds), fill='none', stroke=stroke)
             elif cls == 'TextItem':
-                SubElement(root, 'text', x=str(item.x()),
-                           y=str(item.y() + item.font().pointSize()),
-                           fill=item.defaultTextColor().name()).text = item.toPlainText()
+                SubElement(
+                    root,
+                    'text',
+                    x=str(item.x()),
+                    y=str(item.y() + item.font().pointSize()),
+                    fill=item.defaultTextColor().name(),
+                    **{'font-size': str(item.font().pointSize())}
+                ).text = item.toPlainText()
 
         ElementTree(root).write(path, encoding='utf-8', xml_declaration=True)
 
@@ -323,9 +332,9 @@ class CanvasWidget(QGraphicsView):
     def mouseMoveEvent(self, event):
 
         if self.current_tool == "pan" or self._middle_pan:
-
+            super().mouseMoveEvent(event)
+            return
         if self._middle_pan:
-
             super().mouseMoveEvent(event)
             return
         scene_pos = self.mapToScene(event.pos())

--- a/pictocode/utils.py
+++ b/pictocode/utils.py
@@ -10,20 +10,104 @@ def color_to_hex(qcolor):
     b = qcolor.blue()
     return f'#{r:02X}{g:02X}{b:02X}'
 
+
 def generate_pycode(shapes):
-    """
-    Exemple très simplifié : génère du code Python PyQt5 qui 
-    re-crée les shapes passées en argument.
-    """
-    lines = ['from PyQt5.QtWidgets import QGraphicsRectItem', '']
+    """Génère du code Python (PyQt5) reproduisant la scène fournie."""
+
+    lines = [
+        "from PyQt5.QtWidgets import (",
+        "    QGraphicsScene, QGraphicsRectItem, QGraphicsEllipseItem,",
+        "    QGraphicsLineItem, QGraphicsPathItem, QGraphicsPolygonItem,",
+        "    QGraphicsTextItem",
+        ")",
+        "from PyQt5.QtGui import QPen, QBrush, QColor, QPainterPath, QPolygonF",
+        "from PyQt5.QtCore import QPointF",
+        "",
+        "scene = QGraphicsScene()",
+        "",
+    ]
+
     for i, shp in enumerate(shapes):
-        if hasattr(shp, 'rect'):
-            x, y, w, h = shp.rect().getRect()
-            lines.append(f'# shape {i}')
-            lines.append(f'rect{i} = QGraphicsRectItem({x}, {y}, {w}, {h})')
-            lines.append(f'scene.addItem(rect{i})')
-            lines.append('')
-    return '\n'.join(lines)
+        cls = type(shp).__name__
+        lines.append(f"# shape {i} - {cls}")
+
+        if cls == "Rect":
+            r = shp.rect()
+            lines.append(f"rect{i} = QGraphicsRectItem({r.x()}, {r.y()}, {r.width()}, {r.height()})")
+            color = shp.pen().color().name()
+            width = shp.pen().width()
+            lines.append(f"rect{i}.setPen(QPen(QColor('{color}'), {width}))")
+            if shp.brush().style() != 0:
+                fill = shp.brush().color().name()
+                lines.append(f"rect{i}.setBrush(QBrush(QColor('{fill}')))")
+            lines.append(f"scene.addItem(rect{i})")
+
+        elif cls == "Ellipse":
+            e = shp.rect()
+            lines.append(f"ellipse{i} = QGraphicsEllipseItem({e.x()}, {e.y()}, {e.width()}, {e.height()})")
+            color = shp.pen().color().name()
+            width = shp.pen().width()
+            lines.append(f"ellipse{i}.setPen(QPen(QColor('{color}'), {width}))")
+            if shp.brush().style() != 0:
+                fill = shp.brush().color().name()
+                lines.append(f"ellipse{i}.setBrush(QBrush(QColor('{fill}')))")
+            lines.append(f"scene.addItem(ellipse{i})")
+
+        elif cls == "Line":
+            line = shp.line()
+            lines.append(f"line{i} = QGraphicsLineItem({line.x1()}, {line.y1()}, {line.x2()}, {line.y2()})")
+            color = shp.pen().color().name()
+            width = shp.pen().width()
+            lines.append(f"line{i}.setPen(QPen(QColor('{color}'), {width}))")
+            lines.append(f"scene.addItem(line{i})")
+
+        elif cls == "FreehandPath":
+            path = shp.path()
+            pts = [path.elementAt(j) for j in range(path.elementCount())]
+            is_poly = len(pts) > 2 and pts[0].x == pts[-1].x and pts[0].y == pts[-1].y
+            if is_poly:
+                lines.append(f"poly{i} = QPolygonF([")
+                for p in pts[:-1]:
+                    lines.append(f"    QPointF({p.x}, {p.y}),")
+                lines.append("])")
+                lines.append(f"poly_item{i} = QGraphicsPolygonItem(poly{i})")
+                color = shp.pen().color().name()
+                width = shp.pen().width()
+                lines.append(f"poly_item{i}.setPen(QPen(QColor('{color}'), {width}))")
+                if shp.brush().style() != 0:
+                    fill = shp.brush().color().name()
+                    lines.append(f"poly_item{i}.setBrush(QBrush(QColor('{fill}')))")
+                lines.append(f"scene.addItem(poly_item{i})")
+            else:
+                lines.append(f"path{i} = QPainterPath()")
+                for idx, p in enumerate(pts):
+                    cmd = 'moveTo' if idx == 0 else 'lineTo'
+                    lines.append(f"path{i}.{cmd}({p.x}, {p.y})")
+                lines.append(f"path_item{i} = QGraphicsPathItem(path{i})")
+                color = shp.pen().color().name()
+                width = shp.pen().width()
+                lines.append(f"path_item{i}.setPen(QPen(QColor('{color}'), {width}))")
+                if shp.brush().style() != 0:
+                    fill = shp.brush().color().name()
+                    lines.append(f"path_item{i}.setBrush(QBrush(QColor('{fill}')))")
+                lines.append(f"scene.addItem(path_item{i})")
+
+        elif cls == "TextItem":
+            text = shp.toPlainText().replace("'", "\'")
+            lines.append(f"text{i} = QGraphicsTextItem('{text}')")
+            lines.append(f"text{i}.setPos({shp.x()}, {shp.y()})")
+            color = shp.defaultTextColor().name()
+            size = shp.font().pointSize()
+            lines.append(f"font{i} = text{i}.font()")
+            lines.append(f"font{i}.setPointSize({size})")
+            lines.append(f"text{i}.setFont(font{i})")
+            lines.append(f"text{i}.setDefaultTextColor(QColor('{color}'))")
+            lines.append(f"scene.addItem(text{i})")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
 
 # ---------------------------------------------------------------------------
 def to_pixels(value: float, unit: str, dpi: float = 72) -> float:


### PR DESCRIPTION
## Summary
- extend python code generation for ellipse, line, path/polygon and text
- enhance SVG export for polygons and text font size
- fix missing mouseMoveEvent body to avoid syntax error

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68517af91d2883239860d063a81a34f1