### PR TITLE
Improve shape tools and workspace

### DIFF
--- a/pictocode/ui/toolbar.py
+++ b/pictocode/ui/toolbar.py
@@ -53,7 +53,7 @@ class Toolbar(QToolBar):
         self.addSeparator()
 
         # Palette de couleurs
-        self.currentColor = QColor("black")
+        self.currentColor = QColor("white")
         color_act = QAction("Couleur...", self)
         color_act.triggered.connect(self.choose_color)
         self.addAction(color_act)


### PR DESCRIPTION
## Summary
- add resizable mixin with SHIFT aspect ratio lock
- default shapes are white and show resize handle when selected
- prevent accidental shape creation when selecting existing items
- disable text creation on double click
- darken area outside document and clip grid
- toolbar defaults to white color

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68518418bae08323b484b3ced0f810ff