### PR TITLE
Hide console on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
 # pictocode/__main__.py
 import sys
+import os
 from PyQt5.QtWidgets import QApplication
 from pictocode.ui.main_window import MainWindow
 
 def main():
+    if os.name == "nt":
+        import ctypes
+        ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)
     app = QApplication(sys.argv)
     win = MainWindow()
     win.show()

--- a/pictocode/__main__.py
+++ b/pictocode/__main__.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 import sys
+import os
 from PyQt5.QtWidgets import QApplication, QSplashScreen
 from PyQt5.QtGui import QPixmap, QPainter, QColor, QFont
 from PyQt5.QtCore import Qt, QSettings
 from pictocode.ui.main_window import MainWindow
 
 def main():
+    if os.name == "nt":
+        import ctypes
+        ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)
     app = QApplication(sys.argv)
     settings = QSettings("pictocode", "pictocode")
     show_splash = settings.value("show_splash", True, type=bool)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "PyQt5>=5.15"
     ],
     entry_points={
-        "console_scripts": [
+        "gui_scripts": [
             "pictocode = pictocode.__main__:main"
         ]
     },


### PR DESCRIPTION
## Summary
- avoid showing the console window on Windows by hiding it in `main.py` and `pictocode/__main__.py`
- install pictocode using a GUI entry point so the generated `pictocode.exe` doesn't open a terminal

## Testing
- `python -m py_compile main.py pictocode/__main__.py setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68518654dbdc83238556bc4c13ff4898