### PR TITLE
Add windows panel for toggling docks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,7 @@ Une boîte de dialogue **Préférences > Raccourcis…** permet de modifier les
 combinaisons clavier associées aux principales commandes (ouvrir, enregistrer,
 etc.). Les raccourcis choisis sont sauvegardés et réappliqués au lancement de
 l'application.
+
+### Gestion des fenetres
+
+Un panneau lateral "Panneaux" permet d'activer ou non diverses fenetres : calques, proprietes, barre d'outils ou encore la liste des images importees.

--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -50,7 +50,7 @@ class CanvasWidget(QGraphicsView):
 
         # sélection -> inspecteur
         self.scene.selectionChanged.connect(self._on_selection_changed)
-        self.scene.changed.connect(lambda _: self._mark_dirty())
+        self.scene.changed.connect(lambda _: self._on_scene_changed())
 
     def _draw_doc_frame(self):
         """Dessine le contour en pointillés de la zone de travail."""
@@ -108,6 +108,9 @@ class CanvasWidget(QGraphicsView):
             'color_mode': color_mode,
             'dpi': dpi,
         }
+        parent = self.parent()
+        if hasattr(parent, "layers"):
+            parent.layers.update_layers(self)
 
     def update_document_properties(self, width, height, unit, orientation, color_mode, dpi, name=""):
         """Met à jour les paramètres du document sans toucher aux formes."""
@@ -152,6 +155,9 @@ class CanvasWidget(QGraphicsView):
                 continue
             self.scene.addItem(item)
         self.scene.blockSignals(False)
+        parent = self.parent()
+        if hasattr(parent, "layers"):
+            parent.layers.update_layers(self)
 
     def export_project(self):
         """
@@ -559,10 +565,18 @@ class CanvasWidget(QGraphicsView):
             items = self.scene.selectedItems()
             if items:
                 parent.inspector.set_target(items[0])
+                if hasattr(parent, "layers"):
+                    parent.layers.highlight_item(items[0])
 
     def _mark_dirty(self):
         parent = self.parent()
         if hasattr(parent, "set_dirty"):
             parent.set_dirty(True)
+
+    def _on_scene_changed(self):
+        self._mark_dirty()
+        parent = self.parent()
+        if hasattr(parent, "layers"):
+            parent.layers.update_layers(self)
 
 

--- a/pictocode/ui/imports_dock.py
+++ b/pictocode/ui/imports_dock.py
@@ -1,0 +1,17 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
+import os
+
+class ImportsWidget(QWidget):
+    """Liste simple des images importées."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.list = QListWidget()
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.list)
+
+    def add_image(self, path: str):
+        name = os.path.basename(path)
+        item = QListWidgetItem(name)
+        item.setToolTip(path)
+        self.list.addItem(item)

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -20,6 +20,13 @@ class Inspector(QWidget):
         self.color_btn.setReadOnly(True)
         self.layout.addRow("Couleur :", self.color_btn)
 
+        self.text_field = QLineEdit(self)
+        self.font_field = QLineEdit(self)
+        self.layout.addRow("Texte :", self.text_field)
+        self.layout.addRow("Taille :", self.font_field)
+        self.text_field.hide()
+        self.font_field.hide()
+
         # Item courant
         self._item = None
 
@@ -29,6 +36,8 @@ class Inspector(QWidget):
             (self.y_field, lambda val: self._item.setY(int(val))),
             (self.w_field, lambda val: self._item.setRect(0,0,int(self.w_field.text()), self._item.rect().height())),
             (self.h_field, lambda val: self._item.setRect(0,0,self._item.rect().width(), int(val))),
+            (self.text_field, lambda val: self._item.setPlainText(val) if hasattr(self._item, 'setPlainText') else None),
+            (self.font_field, lambda val: self._set_font_size(int(val))),
         ):
             fld.editingFinished.connect(lambda fld=fld, st=setter: self._update_field(fld, st))
 
@@ -45,6 +54,14 @@ class Inspector(QWidget):
         self.h_field.setText(str(int(r.height())))
         pen = item.pen().color().name() if hasattr(item, "pen") else "#000000"
         self.color_btn.setText(pen)
+        if hasattr(item, 'toPlainText'):
+            self.text_field.show()
+            self.font_field.show()
+            self.text_field.setText(item.toPlainText())
+            self.font_field.setText(str(item.font().pointSize()))
+        else:
+            self.text_field.hide()
+            self.font_field.hide()
 
     def _update_field(self, fld, setter):
         try:
@@ -60,3 +77,10 @@ class Inspector(QWidget):
             pen.setColor(col)
             self._item.setPen(pen)
             self.color_btn.setText(col.name())
+
+    def _set_font_size(self, size: int):
+        if hasattr(self._item, 'font'):
+            f = self._item.font()
+            f.setPointSize(size)
+            self._item.setFont(f)
+

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -1,0 +1,29 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
+from PyQt5.QtCore import Qt
+
+class LayersWidget(QWidget):
+    """Affiche la liste des objets du canvas."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.list = QListWidget()
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.list)
+
+    def update_layers(self, canvas):
+        self.list.clear()
+        if not canvas:
+            return
+        for item in reversed(canvas.scene.items()):
+            if item is getattr(canvas, "_frame_item", None):
+                continue
+            lw = QListWidgetItem(type(item).__name__)
+            lw.setData(Qt.UserRole, item)
+            self.list.addItem(lw)
+
+    def highlight_item(self, item):
+        for row in range(self.list.count()):
+            lw = self.list.item(row)
+            if lw.data(Qt.UserRole) is item:
+                self.list.setCurrentRow(row)
+                break

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -16,6 +16,9 @@ from .home_page import HomePage
 from .new_project_dialog import NewProjectDialog
 from .animated_menu import AnimatedMenu
 from .shortcut_settings_dialog import ShortcutSettingsDialog
+from .layers_dock import LayersWidget
+from .imports_dock import ImportsWidget
+from .windows_panel import WindowsPanel
 
 PROJECTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Projects")
 
@@ -65,6 +68,33 @@ class MainWindow(QMainWindow):
         self.addDockWidget(Qt.RightDockWidgetArea, dock)
         dock.setVisible(False)
         self.inspector_dock = dock
+
+        # Calques
+        self.layers = LayersWidget(self)
+        l_dock = QDockWidget("Calques", self)
+        l_dock.setWidget(self.layers)
+        l_dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.addDockWidget(Qt.LeftDockWidgetArea, l_dock)
+        l_dock.setVisible(False)
+        self.layers_dock = l_dock
+
+        # Images importées
+        self.imports = ImportsWidget(self)
+        i_dock = QDockWidget("Imports", self)
+        i_dock.setWidget(self.imports)
+        i_dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.addDockWidget(Qt.LeftDockWidgetArea, i_dock)
+        i_dock.setVisible(False)
+        self.imports_dock = i_dock
+
+        # Panneau d'activation
+        self.windows_panel = WindowsPanel(self)
+        p_dock = QDockWidget("Panneaux", self)
+        p_dock.setWidget(self.windows_panel)
+        p_dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.addDockWidget(Qt.LeftDockWidgetArea, p_dock)
+        p_dock.setVisible(True)
+        self.panel_dock = p_dock
 
         # Dialog nouveau projet
         self.new_proj_dlg = NewProjectDialog(self)
@@ -244,6 +274,10 @@ class MainWindow(QMainWindow):
         # affiche toolbar & inspector
         self.toolbar.setVisible(True)
         self.inspector_dock.setVisible(True)
+        self.layers_dock.setVisible(True)
+        self.imports_dock.setVisible(True)
+        self.windows_panel.chk_layers.setChecked(True)
+        self.windows_panel.chk_imports.setChecked(True)
         # bascule sur le canvas
         self._switch_page(self.canvas)
         self.current_project_path = None
@@ -276,6 +310,10 @@ class MainWindow(QMainWindow):
         # bascule UI
         self.toolbar.setVisible(True)
         self.inspector_dock.setVisible(True)
+        self.layers_dock.setVisible(True)
+        self.imports_dock.setVisible(True)
+        self.windows_panel.chk_layers.setChecked(True)
+        self.windows_panel.chk_imports.setChecked(True)
         self._switch_page(self.canvas)
         self.setWindowTitle(f"Pictocode — {params.get('name','')}")
         self.set_dirty(False)
@@ -493,6 +531,10 @@ class MainWindow(QMainWindow):
         self.inspector.setStyleSheet(
             f"font-size: {dock_font_size}pt;"
         )
+        for dock in (self.layers_dock, self.imports_dock, self.panel_dock):
+            dock.setStyleSheet(f"QDockWidget {{ background: {dock_color.name()}; }}")
+        for widget in (self.layers, self.imports, self.windows_panel):
+            widget.setStyleSheet(f"font-size: {dock_font_size}pt;")
 
         self.current_theme = theme
         self.accent_color = accent

--- a/pictocode/ui/windows_panel.py
+++ b/pictocode/ui/windows_panel.py
@@ -1,0 +1,23 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QCheckBox
+from PyQt5.QtCore import Qt
+
+class WindowsPanel(QWidget):
+    """Permet d'activer ou désactiver différentes fenêtres."""
+
+    def __init__(self, main_window, parent=None):
+        super().__init__(parent)
+        self.main = main_window
+        layout = QVBoxLayout(self)
+        self.chk_layers = QCheckBox('Calques')
+        self.chk_props = QCheckBox('Propriétés')
+        self.chk_toolbar = QCheckBox("Barre d'outils")
+        self.chk_imports = QCheckBox('Imports')
+        for chk in (self.chk_layers, self.chk_props, self.chk_toolbar, self.chk_imports):
+            layout.addWidget(chk)
+        self.chk_layers.stateChanged.connect(lambda s: self.main.layers_dock.setVisible(s == Qt.Checked))
+        self.chk_props.stateChanged.connect(lambda s: self.main.inspector_dock.setVisible(s == Qt.Checked))
+        self.chk_toolbar.stateChanged.connect(lambda s: self.main.toolbar.setVisible(s == Qt.Checked))
+        self.chk_imports.stateChanged.connect(lambda s: self.main.imports_dock.setVisible(s == Qt.Checked))
+        # états initiaux
+        self.chk_props.setChecked(True)
+        self.chk_toolbar.setChecked(True)


### PR DESCRIPTION
## Summary
- implement LayersWidget, ImportsWidget and WindowsPanel docks
- extend Inspector to edit text items and font size
- update MainWindow to manage new docks
- update Canvas to refresh layers on changes
- document windows panel in README

## Testing
- `python -m compileall -q pictocode`
- `python -m pictocode --help` *(fails: Qt platform plugin not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6851861dc5e88323a3276d7d98ddee81