### PR TITLE
Hide docks on home screen and refresh home UI

### DIFF
--- a/pictocode/ui/home_page.py
+++ b/pictocode/ui/home_page.py
@@ -89,40 +89,38 @@ class HomePage(QWidget):
         self.setStyleSheet(
             """
             QWidget#home {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-                    stop:0 #4e54c8, stop:1 #8f94fb);
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
+                    stop:0 #374ABE, stop:1 #64B6FF);
             }
             QLabel#title_label {
-                font-size: 24px;
+                font-size: 26px;
                 font-weight: bold;
                 color: white;
-                padding: 16px;
+                padding: 20px;
             }
             QLabel#subtitle_label {
-                font-size: 14px;
+                font-size: 16px;
                 color: white;
-                padding-bottom: 12px;
+                padding-bottom: 16px;
             }
             QListWidget#favorites_list,
-            QListWidget#recent_list {
-                background: rgba(255, 255, 255, 0.85);
-                border-radius: 8px;
-                padding: 6px;
+            QListWidget#recent_list,
+            QListWidget#template_list {
+                background: rgba(255, 255, 255, 0.9);
+                border-radius: 10px;
+                padding: 8px;
             }
             QListWidget#template_list {
-                background: rgba(255, 255, 255, 0.6);
-                border-radius: 8px;
-                padding: 4px;
-                margin-top: 8px;
+                margin-top: 12px;
             }
             QListWidget#favorites_list::item,
             QListWidget#recent_list::item {
-                padding: 6px;
+                padding: 8px;
             }
             QLabel#section_label {
                 color: white;
                 font-weight: bold;
-                margin-top: 8px;
+                margin-top: 12px;
             }
             """
         )

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -374,6 +374,8 @@ class MainWindow(QMainWindow):
         self.imports_dock.setVisible(True)
         self.windows_panel.chk_layers.setChecked(True)
         self.windows_panel.chk_imports.setChecked(True)
+        self.windows_panel.chk_toolbar.setChecked(True)
+        self.windows_panel.chk_props.setChecked(True)
         # bascule sur le canvas
         self._switch_page(self.canvas)
         self.current_project_path = None
@@ -421,6 +423,8 @@ class MainWindow(QMainWindow):
         self.imports_dock.setVisible(True)
         self.windows_panel.chk_layers.setChecked(True)
         self.windows_panel.chk_imports.setChecked(True)
+        self.windows_panel.chk_toolbar.setChecked(True)
+        self.windows_panel.chk_props.setChecked(True)
         self._switch_page(self.canvas)
         self.setWindowTitle(f"Pictocode — {params.get('name','')}")
         self.set_dirty(False)
@@ -508,6 +512,10 @@ class MainWindow(QMainWindow):
         self.layers_dock.setVisible(False)
         self.imports_dock.setVisible(False)
         self.panel_dock.setVisible(False)
+        self.windows_panel.chk_layers.setChecked(False)
+        self.windows_panel.chk_imports.setChecked(False)
+        self.windows_panel.chk_toolbar.setChecked(False)
+        self.windows_panel.chk_props.setChecked(False)
 
     # --- Edit actions -------------------------------------------------
     def copy_selection(self):

--- a/pictocode/ui/windows_panel.py
+++ b/pictocode/ui/windows_panel.py
@@ -14,10 +14,27 @@ class WindowsPanel(QWidget):
         self.chk_imports = QCheckBox('Imports')
         for chk in (self.chk_layers, self.chk_props, self.chk_toolbar, self.chk_imports):
             layout.addWidget(chk)
-        self.chk_layers.stateChanged.connect(lambda s: self.main.layers_dock.setVisible(s == Qt.Checked))
-        self.chk_props.stateChanged.connect(lambda s: self.main.inspector_dock.setVisible(s == Qt.Checked))
-        self.chk_toolbar.stateChanged.connect(lambda s: self.main.toolbar.setVisible(s == Qt.Checked))
-        self.chk_imports.stateChanged.connect(lambda s: self.main.imports_dock.setVisible(s == Qt.Checked))
-        # états initiaux
-        self.chk_props.setChecked(True)
-        self.chk_toolbar.setChecked(True)
+
+        self.chk_layers.stateChanged.connect(
+            lambda s: self.main.layers_dock.setVisible(s == Qt.Checked)
+        )
+        self.chk_props.stateChanged.connect(
+            lambda s: self.main.inspector_dock.setVisible(s == Qt.Checked)
+        )
+        self.chk_toolbar.stateChanged.connect(
+            lambda s: self.main.toolbar.setVisible(s == Qt.Checked)
+        )
+        self.chk_imports.stateChanged.connect(
+            lambda s: self.main.imports_dock.setVisible(s == Qt.Checked)
+        )
+
+        # synchronise les cases avec l'état courant sans déclencher de signal
+        for chk, visible in (
+            (self.chk_layers, self.main.layers_dock.isVisible()),
+            (self.chk_props, self.main.inspector_dock.isVisible()),
+            (self.chk_toolbar, self.main.toolbar.isVisible()),
+            (self.chk_imports, self.main.imports_dock.isVisible()),
+        ):
+            chk.blockSignals(True)
+            chk.setChecked(visible)
+            chk.blockSignals(False)


### PR DESCRIPTION
## Summary
- improve WindowsPanel so checkboxes reflect visible docks without enabling them on start
- show or hide dock widgets when switching pages
- modernize the home page gradient and typography

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685193eac08c8323a7f419aeccd7a831