### PR TITLE
Fix selection crash and enable free object movement

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -663,6 +663,8 @@ class CanvasWidget(QGraphicsView):
                 parent.inspector.set_target(items[0])
                 if hasattr(parent, "layers"):
                     parent.layers.highlight_item(items[0])
+            else:
+                parent.inspector.set_target(None)
 
     def _mark_dirty(self):
         parent = self.parent()
@@ -674,6 +676,13 @@ class CanvasWidget(QGraphicsView):
         parent = self.parent()
         if hasattr(parent, "layers"):
             parent.layers.update_layers(self)
+
+        # Agrandit automatiquement la zone de la scène pour permettre
+        # le déplacement libre des formes en dehors du document initial.
+        bounds = self.scene.itemsBoundingRect().adjusted(-50, -50, 50, 50)
+        if not bounds.contains(self._doc_rect):
+            bounds = bounds.united(self._doc_rect)
+            self.setSceneRect(bounds)
 
     # --- Clipboard / editing helpers ---------------------------------
     def _serialize_item(self, item):

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -61,6 +61,19 @@ class Inspector(QWidget):
     def set_target(self, item):
         """Appelé par le Canvas quand un item est sélectionné."""
         self._item = item
+        if item is None:
+            for fld in (
+                self.x_field,
+                self.y_field,
+                self.w_field,
+                self.h_field,
+                self.color_btn,
+            ):
+                fld.setText("")
+            self.text_field.hide()
+            self.font_field.hide()
+            return
+
         r = item.rect() if hasattr(item, "rect") else item.boundingRect()
         self.x_field.setText(str(int(item.x())))
         self.y_field.setText(str(int(item.y())))
@@ -68,7 +81,7 @@ class Inspector(QWidget):
         self.h_field.setText(str(int(r.height())))
         pen = item.pen().color().name() if hasattr(item, "pen") else "#000000"
         self.color_btn.setText(pen)
-        if hasattr(item, 'toPlainText'):
+        if hasattr(item, "toPlainText"):
             self.text_field.show()
             self.font_field.show()
             self.text_field.setText(item.toPlainText())


### PR DESCRIPTION
## Summary
- avoid inspector errors when nothing is selected
- update selection change handler to clear inspector
- expand scene rect dynamically so items can move outside project bounds

## Testing
- `python -m py_compile pictocode/ui/inspector.py pictocode/canvas.py`

------
https://chatgpt.com/codex/tasks/task_e_685198990054832381070c5f0a8289fd