### PR TITLE
Implement image import and universal resizing

### DIFF
--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -60,6 +60,7 @@ class MainWindow(QMainWindow):
         self.settings = QSettings("pictocode", "pictocode")
         self.favorite_projects = self.settings.value("favorite_projects", [], type=list)
         self.recent_projects = self.settings.value("recent_projects", [], type=list)
+        self.imported_images = self.settings.value("imported_images", [], type=list)
 
         # Page accueil
         self.home = HomePage(self)
@@ -100,6 +101,8 @@ class MainWindow(QMainWindow):
         self.addDockWidget(Qt.LeftDockWidgetArea, i_dock)
         i_dock.setVisible(False)
         self.imports_dock = i_dock
+        for img in self.imported_images:
+            self.imports.add_image(img)
 
 
 
@@ -813,6 +816,13 @@ class MainWindow(QMainWindow):
         else:
             self.favorite_projects.insert(0, path)
         self.settings.setValue("favorite_projects", self.favorite_projects)
+
+    def add_imported_image(self, path: str):
+        if path in self.imported_images:
+            self.imported_images.remove(path)
+        self.imported_images.insert(0, path)
+        self.settings.setValue("imported_images", self.imported_images)
+        self.imports.add_image(path)
 
 
 def main(app, argv):

--- a/pictocode/ui/toolbar.py
+++ b/pictocode/ui/toolbar.py
@@ -36,6 +36,10 @@ class Toolbar(QToolBar):
         text_act.triggered.connect(lambda: self.canvas.set_tool("text"))
         self.addAction(text_act)
 
+        img_act = QAction("Image...", self)
+        img_act.triggered.connect(self.import_image)
+        self.addAction(img_act)
+
         # Pan / déplacement du plan de travail
         pan_act = QAction("Pan", self)
         pan_act.triggered.connect(lambda: self.canvas.set_tool("pan"))
@@ -58,6 +62,17 @@ class Toolbar(QToolBar):
         color_act = QAction("Couleur...", self)
         color_act.triggered.connect(self.choose_color)
         self.addAction(color_act)
+
+    def import_image(self):
+        from PyQt5.QtWidgets import QFileDialog
+
+        path, _ = QFileDialog.getOpenFileName(
+            self.parent(), "Importer une image", "", "Images (*.png *.jpg *.jpeg *.bmp *.gif)"
+        )
+        if path:
+            item = self.canvas.insert_image(path)
+            if item:
+                self.parent().add_imported_image(path)
 
     def choose_color(self):
         """Ouvre une palette, récupère la couleur et la passe au canvas."""


### PR DESCRIPTION
## Summary
- add resizable mixin to more shapes and new `ImageItem`
- support line handle resizing
- allow text blocks and paths to resize
- enable importing images and keep list globally
- add action for inserting images via toolbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519f0b4a288323bcc3359393f556f0