### PR TITLE
Extend inspector with adjustable controls

### DIFF
--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -261,6 +261,7 @@ class Rect(ResizableMixin, SnapToGridMixin, QGraphicsRectItem):
             | QGraphicsRectItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
 
     def rect(self):
@@ -290,6 +291,7 @@ class Ellipse(ResizableMixin, SnapToGridMixin, QGraphicsEllipseItem):
             | QGraphicsEllipseItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
 
     def rect(self):
@@ -386,6 +388,7 @@ class Line(LineResizableMixin, SnapToGridMixin, QGraphicsLineItem):
             | QGraphicsLineItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
 
 
@@ -411,6 +414,7 @@ class FreehandPath(ResizableMixin, SnapToGridMixin, QGraphicsPathItem):
             | QGraphicsPathItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
 
     def rect(self):
@@ -470,6 +474,8 @@ class TextItem(ResizableMixin, SnapToGridMixin, QGraphicsTextItem):
             | QGraphicsTextItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
+        self.alignment = "left"
         self.setToolTip("Clique droit pour modifier")
 
     def itemChange(self, change, value):
@@ -510,6 +516,7 @@ class ImageItem(ResizableMixin, SnapToGridMixin, QGraphicsPixmapItem):
             | QGraphicsPixmapItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.var_name = ""
 
     def rect(self):
         return QRectF(0, 0, self.pixmap().width(), self.pixmap().height())

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -4,9 +4,11 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QLineEdit,
     QColorDialog,
-    QSpinBox,
     QPushButton,
+    QComboBox,
 )
+from PyQt5.QtCore import Qt
+from .step_spinbox import StepSpinBox
 
 
 class Inspector(QWidget):
@@ -14,24 +16,43 @@ class Inspector(QWidget):
         super().__init__(parent)
         self.layout = QFormLayout(self)
 
-        self.x_field = QSpinBox(self)
+        self.x_field = StepSpinBox(self)
         self.x_field.setRange(-10000, 10000)
-        self.y_field = QSpinBox(self)
+        self.y_field = StepSpinBox(self)
         self.y_field.setRange(-10000, 10000)
-        self.w_field = QSpinBox(self)
+        self.w_field = StepSpinBox(self)
         self.w_field.setRange(1, 10000)
-        self.h_field = QSpinBox(self)
+        self.h_field = StepSpinBox(self)
         self.h_field.setRange(1, 10000)
+        self.rotation_field = StepSpinBox(self)
+        self.rotation_field.setRange(-360, 360)
+        self.z_field = StepSpinBox(self)
+        self.z_field.setRange(-1000, 1000)
+        self.border_field = StepSpinBox(self)
+        self.border_field.setRange(0, 100)
+        self.var_field = QLineEdit(self)
+        self.align_field = QComboBox(self)
+        self.align_field.addItems(["left", "center", "right"])
+        self.fill_btn = QPushButton()
+        self.fill_btn.setFixedWidth(40)
+        self.fill_btn.clicked.connect(self._pick_fill)
+        self._update_fill_button("#ffffff")
         self.layout.addRow("X :", self.x_field)
         self.layout.addRow("Y :", self.y_field)
         self.layout.addRow("W :", self.w_field)
         self.layout.addRow("H :", self.h_field)
+        self.layout.addRow("Rotation :", self.rotation_field)
+        self.layout.addRow("Calque :", self.z_field)
+        self.layout.addRow("Largeur bordure :", self.border_field)
 
         self.color_btn = QPushButton()
         self.color_btn.setFixedWidth(40)
         self.color_btn.clicked.connect(self._pick_color)
         self._update_color_button("#000000")
-        self.layout.addRow("Couleur :", self.color_btn)
+        self.layout.addRow("Couleur bordure :", self.color_btn)
+        self.layout.addRow("Couleur fond :", self.fill_btn)
+        self.layout.addRow("Variable :", self.var_field)
+        self.layout.addRow("Alignement :", self.align_field)
 
         self.text_field = QLineEdit(self)
         self.font_field = QLineEdit(self)
@@ -47,7 +68,6 @@ class Inspector(QWidget):
         for fld, setter in (
             (self.x_field, lambda val: self._item.setX(int(val))),
             (self.y_field, lambda val: self._item.setY(int(val))),
-
             (
                 self.w_field,
                 lambda val: self._item.setRect(
@@ -60,9 +80,13 @@ class Inspector(QWidget):
                     0, 0, self._item.rect().width(), int(val)
                 ),
             ),
+            (self.rotation_field, lambda val: self._item.setRotation(int(val))),
+            (self.z_field, lambda val: self._item.setZValue(int(val))),
+            (self.border_field, self._set_pen_width),
+            (self.var_field, self._set_var_name),
+            (self.align_field, self._set_alignment),
             (self.text_field, lambda val: self._item.setPlainText(val) if hasattr(self._item, 'setPlainText') else None),
             (self.font_field, lambda val: self._set_font_size(int(val))),
-
         ):
             fld.editingFinished.connect(
                 lambda fld=fld, st=setter: self._update_field(fld, st)
@@ -79,9 +103,14 @@ class Inspector(QWidget):
                 self.y_field,
                 self.w_field,
                 self.h_field,
+                self.rotation_field,
+                self.z_field,
+                self.border_field,
             ):
                 fld.setValue(0)
+            self.var_field.setText("")
             self._update_color_button("#000000")
+            self._update_fill_button("#ffffff")
             self.text_field.hide()
             self.font_field.hide()
             return
@@ -93,6 +122,17 @@ class Inspector(QWidget):
         self.h_field.setValue(int(r.height()))
         pen = item.pen().color().name() if hasattr(item, "pen") else "#000000"
         self._update_color_button(pen)
+        if hasattr(item, "brush"):
+            self._update_fill_button(item.brush().color().name())
+        self.rotation_field.setValue(int(item.rotation()))
+        self.z_field.setValue(int(item.zValue()))
+        if hasattr(item, "pen"):
+            self.border_field.setValue(item.pen().width())
+        self.var_field.setText(getattr(item, "var_name", ""))
+        if hasattr(item, "alignment"):
+            idx = self.align_field.findText(getattr(item, "alignment", "left"))
+            if idx >= 0:
+                self.align_field.setCurrentIndex(idx)
         if hasattr(item, "toPlainText"):
             self.text_field.show()
             self.font_field.show()
@@ -104,7 +144,12 @@ class Inspector(QWidget):
 
     def _update_field(self, fld, setter):
         try:
-            value = fld.value() if hasattr(fld, "value") else fld.text()
+            if hasattr(fld, "value"):
+                value = fld.value()
+            elif hasattr(fld, "currentText"):
+                value = fld.currentText()
+            else:
+                value = fld.text()
             setter(value)
         except Exception:
             pass
@@ -128,6 +173,34 @@ class Inspector(QWidget):
             f.setPointSize(size)
             self._item.setFont(f)
 
+    def _set_pen_width(self, width: int):
+        if hasattr(self._item, 'pen'):
+            pen = self._item.pen()
+            pen.setWidth(int(width))
+            self._item.setPen(pen)
+
+    def _set_var_name(self, name: str):
+        if self._item is not None:
+            setattr(self._item, 'var_name', name)
+
+    def _set_alignment(self, _val):
+        if hasattr(self._item, 'alignment'):
+            self._item.alignment = self.align_field.currentText()
+
     def _update_color_button(self, color: str):
         self.color_btn.setStyleSheet(f"background:{color};")
+
+    def _pick_fill(self, event=None):
+        if not self._item or not hasattr(self._item, 'brush'):
+            return
+        col = QColorDialog.getColor(parent=self)
+        if col.isValid():
+            brush = self._item.brush()
+            brush.setColor(col)
+            brush.setStyle(Qt.SolidPattern)
+            self._item.setBrush(brush)
+            self._update_fill_button(col.name())
+
+    def _update_fill_button(self, color: str):
+        self.fill_btn.setStyleSheet(f"background:{color};")
 

--- a/pictocode/ui/step_spinbox.py
+++ b/pictocode/ui/step_spinbox.py
@@ -1,0 +1,31 @@
+from PyQt5.QtWidgets import QSpinBox
+from PyQt5.QtCore import Qt
+
+class StepSpinBox(QSpinBox):
+    """SpinBox with adjustable wheel step and precision."""
+
+    def __init__(self, parent=None, base_step=1):
+        super().__init__(parent)
+        self._base_step = base_step
+        self._level = 1
+        self.setSingleStep(base_step)
+
+    def wheelEvent(self, event):
+        step = self._base_step * self._level
+        if event.modifiers() & Qt.ShiftModifier:
+            step = step / 10 if step > 0 else step
+        delta = event.angleDelta().y()
+        if delta > 0:
+            self.setValue(self.value() + step)
+        else:
+            self.setValue(self.value() - step)
+        event.accept()
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Plus, Qt.Key_Equal):
+            self._level += 1
+        elif event.key() == Qt.Key_Minus:
+            self._level = max(1, self._level - 1)
+        else:
+            super().keyPressEvent(event)
+        self.setSingleStep(self._base_step * self._level)


### PR DESCRIPTION
## Summary
- add adjustable `StepSpinBox` supporting wheel and +/- control
- expand inspector to show rotation, z-index, border width, fill color and variable
- store `var_name` (and alignment for text) on shapes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685270e1cc688323b8cbee42e1bfdb32