### PR TITLE
Fix layer list updates when adding items

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -331,6 +331,7 @@ class CanvasWidget(QGraphicsView):
                 if items and items[0] is not self._frame_item:
                     self.scene.removeItem(items[0])
                     self._mark_dirty()
+                    self._on_scene_changed()
             elif self.current_tool in ("rect", "ellipse", "line"):
                 items = [
                     it
@@ -369,6 +370,7 @@ class CanvasWidget(QGraphicsView):
                 item.setSelected(True)
                 item.setTextInteractionFlags(Qt.TextEditorInteraction)
                 self._mark_dirty()
+                self._on_scene_changed()
             elif self.current_tool == "polygon":
                 if self._polygon_points is None:
                     self._polygon_points = [scene_pos]
@@ -486,6 +488,7 @@ class CanvasWidget(QGraphicsView):
             self._current_path_item = None
             self._freehand_points = None
             self._mark_dirty()
+            self._on_scene_changed()
         elif self._temp_item and self._start_pos:
             x0, y0 = self._start_pos.x(), self._start_pos.y()
             if self.current_tool in ("rect", "ellipse"):
@@ -499,6 +502,7 @@ class CanvasWidget(QGraphicsView):
             self._assign_layer_name(self._temp_item)
             self._temp_item = None
             self._mark_dirty()
+            self._on_scene_changed()
             self._start_pos = None
             return
         self._start_pos = None
@@ -525,6 +529,7 @@ class CanvasWidget(QGraphicsView):
             self._polygon_item = None
             self._polygon_points = None
             self._mark_dirty()
+            self._on_scene_changed()
         elif items and isinstance(items[0], TextItem):
             ti = items[0]
             ti.setTextInteractionFlags(Qt.TextEditorInteraction)
@@ -591,7 +596,11 @@ class CanvasWidget(QGraphicsView):
                 menu.addAction(act_fill)
             act_delete = QAction("Supprimer", self)
             act_delete.triggered.connect(
-                lambda: (self.scene.removeItem(item), self._mark_dirty())
+                lambda: (
+                    self.scene.removeItem(item),
+                    self._mark_dirty(),
+                    self._on_scene_changed(),
+                )
             )
             menu.addAction(act_delete)
             act_props = QAction("Propriétés…", self)
@@ -644,6 +653,7 @@ class CanvasWidget(QGraphicsView):
         self.scene.addItem(item)
         self._assign_layer_name(item)
         self._mark_dirty()
+        self._on_scene_changed()
         return item
 
     def _change_pen_width(self, item):
@@ -879,6 +889,7 @@ class CanvasWidget(QGraphicsView):
             for it in self.scene.selectedItems():
                 self.scene.removeItem(it)
             self._mark_dirty()
+            self._on_scene_changed()
         return data
 
     def paste_item(self, data):
@@ -890,6 +901,7 @@ class CanvasWidget(QGraphicsView):
         if item:
             item.setSelected(True)
             self._mark_dirty()
+            self._on_scene_changed()
 
     def duplicate_selected(self):
         data = self.copy_selected()
@@ -911,6 +923,7 @@ class CanvasWidget(QGraphicsView):
         for it in self.scene.selectedItems():
             self.scene.removeItem(it)
         self._mark_dirty()
+        self._on_scene_changed()
 
     def select_all(self):
         for it in self.scene.items():


### PR DESCRIPTION
## Summary
- ensure layers update when drawing or editing
- trigger layer refresh on cut, paste, delete and insert image

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pictocode --help` *(fails: Qt platform plugin 'xcb' could not be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68527e98c23c83238ed2e564a4fb713b