### PR TITLE
Improve layers UI and add autosave option

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1074,3 +1074,14 @@ class CanvasWidget(QGraphicsView):
             ch.setSelected(True)
         self._schedule_scene_changed()
 
+    def create_collection(self, name: str = "collection"):
+        """Crée un groupe vide (collection) dans la scène."""
+        group = QGraphicsItemGroup()
+        self.scene.addItem(group)
+        group.setFlags(
+            QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
+        )
+        self._assign_layer_name(group, name)
+        self._schedule_scene_changed()
+        return group
+

--- a/pictocode/ui/app_settings_dialog.py
+++ b/pictocode/ui/app_settings_dialog.py
@@ -33,6 +33,8 @@ class AppSettingsDialog(QDialog):
         rotation_offset: int = 20,
         handle_color: Optional[Union[QColor, str]] = None,
         rotation_handle_color: Optional[Union[QColor, str]] = None,
+        autosave_enabled: bool = False,
+        autosave_interval: int = 5,
         parent=None,
     ):
 
@@ -130,6 +132,15 @@ class AppSettingsDialog(QDialog):
         self.rotation_handle_color_edit.mousePressEvent = lambda e: self._choose_color("rotation_handle")
         form.addRow("Couleur rotation :", self.rotation_handle_color_edit)
 
+        self.autosave_chk = QCheckBox()
+        self.autosave_chk.setChecked(bool(autosave_enabled))
+        form.addRow("Sauvegarde auto :", self.autosave_chk)
+
+        self.autosave_spin = QSpinBox()
+        self.autosave_spin.setRange(1, 60)
+        self.autosave_spin.setValue(int(autosave_interval))
+        form.addRow("Intervalle (min) :", self.autosave_spin)
+
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
         )
@@ -186,3 +197,9 @@ class AppSettingsDialog(QDialog):
 
     def get_rotation_handle_color(self) -> QColor:
         return self.rotation_handle_color
+
+    def get_autosave_enabled(self) -> bool:
+        return self.autosave_chk.isChecked()
+
+    def get_autosave_interval(self) -> int:
+        return self.autosave_spin.value()

--- a/pictocode/ui/title_bar.py
+++ b/pictocode/ui/title_bar.py
@@ -17,7 +17,12 @@ class TitleBar(QWidget):
 
         self.title_label = QLabel("Pictocode", self)
         self.title_label.setObjectName("titlebar_label")
-        layout.addWidget(self.title_label, 1)
+        layout.addWidget(self.title_label)
+
+        self.status_label = QLabel("", self)
+        self.status_label.setObjectName("save_status")
+        self.status_label.hide()
+        layout.addWidget(self.status_label, 1, alignment=Qt.AlignRight)
 
         self.min_btn = QPushButton("–", self)
         self.min_btn.setObjectName("titlebar_min")
@@ -35,6 +40,8 @@ class TitleBar(QWidget):
         layout.addWidget(self.close_btn)
 
         self._maximized = False
+        
+        self._status_timer = None
 
     def _toggle_max(self):
         if self._maximized:
@@ -72,3 +79,12 @@ class TitleBar(QWidget):
         if event.button() == Qt.LeftButton:
             self._toggle_max()
         super().mouseDoubleClickEvent(event)
+
+    def show_status(self, text: str):
+        from PyQt5.QtCore import QTimer
+
+        self.status_label.setText(text)
+        self.status_label.show()
+        if self._status_timer:
+            self._status_timer.stop()
+        self._status_timer = QTimer.singleShot(2000, self.status_label.hide)


### PR DESCRIPTION
## Summary
- support empty collection creation from canvas
- rework layers dock design with icons and drag animation
- add autosave settings and show save status in title bar
- fix save prompt appearing on home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852a17d0db483239d36928eddeca24b