### PR TITLE
Add rotation axis & live inspector

### DIFF
--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -39,11 +39,11 @@ class SnapToGridMixin:
 class ResizableMixin:
     """Ajoute des poignées de redimensionnement et la logique associée."""
 
-    handle_size = 8
+    handle_size = 12
     handle_color = Qt.black
-    handle_shape = "square"  # or "circle"
+    handle_shape = "circle"  # or "circle"
 
-    rotation_handle_size = 10
+    rotation_handle_size = 12
     rotation_handle_color = Qt.red
     rotation_handle_shape = "circle"
     rotation_offset = 20
@@ -331,7 +331,7 @@ class Ellipse(ResizableMixin, SnapToGridMixin, QGraphicsEllipseItem):
 class LineResizableMixin:
     """Ajoute des poignées de redimensionnement pour les lignes."""
 
-    handle_size = 8
+    handle_size = 12
 
     def __init__(self):
         super().__init__()

--- a/pictocode/ui/app_settings_dialog.py
+++ b/pictocode/ui/app_settings_dialog.py
@@ -29,7 +29,7 @@ class AppSettingsDialog(QDialog):
         toolbar_font_size: Optional[int] = None,
         dock_font_size: Optional[int] = None,
         show_splash: bool = True,
-        handle_size: int = 8,
+        handle_size: int = 12,
         rotation_offset: int = 20,
         handle_color: Optional[Union[QColor, str]] = None,
         rotation_handle_color: Optional[Union[QColor, str]] = None,

--- a/pictocode/ui/title_bar.py
+++ b/pictocode/ui/title_bar.py
@@ -19,10 +19,6 @@ class TitleBar(QWidget):
         self.title_label.setObjectName("titlebar_label")
         layout.addWidget(self.title_label)
 
-        self.status_label = QLabel("", self)
-        self.status_label.setObjectName("save_status")
-        self.status_label.hide()
-        layout.addWidget(self.status_label, 1, alignment=Qt.AlignRight)
 
         self.min_btn = QPushButton("–", self)
         self.min_btn.setObjectName("titlebar_min")
@@ -40,8 +36,6 @@ class TitleBar(QWidget):
         layout.addWidget(self.close_btn)
 
         self._maximized = False
-        
-        self._status_timer = None
 
     def _toggle_max(self):
         if self._maximized:
@@ -81,10 +75,6 @@ class TitleBar(QWidget):
         super().mouseDoubleClickEvent(event)
 
     def show_status(self, text: str):
-        from PyQt5.QtCore import QTimer
-
-        self.status_label.setText(text)
-        self.status_label.show()
-        if self._status_timer:
-            self._status_timer.stop()
-        self._status_timer = QTimer.singleShot(2000, self.status_label.hide)
+        """Delegate status display to the main window."""
+        if hasattr(self._parent, "show_status"):
+            self._parent.show_status(text)


### PR DESCRIPTION
## Summary
- show save message below title bar
- enlarge round resize handles by default
- let inspector apply changes immediately
- add opacity and gradient options
- allow setting rotation axis

## Testing
- `python -m compileall -q pictocode/ui/inspector.py pictocode/ui/main_window.py pictocode/ui/title_bar.py pictocode/shapes.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852b7d1fcf083239c040d68113e5085