### PR TITLE
Fix resize handle alignment when rotating shapes

### DIFF
--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -204,9 +204,10 @@ class ResizableMixin:
 
     def mouseMoveEvent(self, event):
         if self._resizing:
-            delta_scene = event.scenePos() - self._start_scene_pos
             # Convert the mouse movement to item coordinates to account for
-            # the current rotation.
+            # the current rotation. Using the item-space delta ensures that
+            # the resize handles follow the cursor correctly when the item
+            # is rotated.
             start_local = self.mapFromScene(self._start_scene_pos)
             current_local = self.mapFromScene(event.scenePos())
             delta_item = current_local - start_local
@@ -217,30 +218,30 @@ class ResizableMixin:
             h = self._start_rect.height()
 
             if self._active_handle == 0:  # top-left
-                x += delta_scene.x()
-                y += delta_scene.y()
+                x += delta_item.x()
+                y += delta_item.y()
                 w -= delta_item.x()
                 h -= delta_item.y()
             elif self._active_handle == 1:  # top-right
-                y += delta_scene.y()
+                y += delta_item.y()
                 w += delta_item.x()
                 h -= delta_item.y()
             elif self._active_handle == 2:  # bottom-right
                 w += delta_item.x()
                 h += delta_item.y()
             elif self._active_handle == 3:  # bottom-left
-                x += delta_scene.x()
+                x += delta_item.x()
                 w -= delta_item.x()
                 h += delta_item.y()
             elif self._active_handle == 4:  # top
-                y += delta_scene.y()
+                y += delta_item.y()
                 h -= delta_item.y()
             elif self._active_handle == 5:  # right
                 w += delta_item.x()
             elif self._active_handle == 6:  # bottom
                 h += delta_item.y()
             elif self._active_handle == 7:  # left
-                x += delta_scene.x()
+                x += delta_item.x()
                 w -= delta_item.x()
             if event.modifiers() & Qt.ShiftModifier and w and h:
                 aspect = self._start_rect.width() / self._start_rect.height()


### PR DESCRIPTION
## Summary
- ensure resize computations use item-space deltas

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852c6a8707c83238b0622ae5c87cbbd