### PR TITLE
Fix layer docking highlight and dark theme

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -98,6 +98,10 @@ class LayersWidget(QWidget):
 
         self._apply_styles()
 
+    def apply_theme(self):
+        """Re-apply styles when the application theme changes."""
+        self._apply_styles()
+
         self.tree.itemClicked.connect(self._on_item_clicked)
         self.tree.itemChanged.connect(self._on_item_changed)
         self.tree.itemSelectionChanged.connect(self._on_selection_changed)
@@ -200,6 +204,7 @@ class LayersWidget(QWidget):
 
     # ------------------------------------------------------------------
     def _on_item_clicked(self, titem, column):
+        self.tree.setCurrentItem(titem)
         gitem = titem.data(0, Qt.UserRole)
         if not gitem:
             return

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -913,6 +913,8 @@ class MainWindow(QMainWindow):
             dock.setStyleSheet(f"QDockWidget {{ background: {dock_color.name()}; }}")
         for widget in (self.layers, self.imports):
             widget.setStyleSheet(f"font-size: {dock_font_size}pt;")
+            if hasattr(widget, "apply_theme"):
+                widget.apply_theme()
 
 
         self.current_theme = theme


### PR DESCRIPTION
## Summary
- keep the clicked layer selected
- refresh layer styles when theme changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852d6e3ed988323a63fa902860eb564