### PR TITLE
Fix highlight crash during drop

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -33,8 +33,14 @@ class LayersTreeWidget(QTreeWidget):
 
     def _clear_highlight(self):
         if self._highlight_item:
-            for c in range(self.columnCount()):
-                self._highlight_item.setBackground(c, QBrush())
+            # The QTreeWidgetItem may have been removed from the tree during a
+            # drop operation. When this happens Qt deletes the underlying C++
+            # object and calling methods on it raises a RuntimeError. Guard by
+            # checking that the item still belongs to a tree before clearing
+            # its background colors.
+            if self._highlight_item.treeWidget() is not None:
+                for c in range(self.columnCount()):
+                    self._highlight_item.setBackground(c, QBrush())
             self._highlight_item = None
 
     def dragMoveEvent(self, event):


### PR DESCRIPTION
## Summary
- avoid calling methods on deleted items when clearing drop highlight

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `python -m pictocode` *(fails: Could not load the Qt platform plugin "xcb".*)

------
https://chatgpt.com/codex/tasks/task_e_6852d9b59e248323b0a2675a900785cc