### PR TITLE
Fix layer order bouncing when grouping items

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -406,6 +406,9 @@ class LayersWidget(QWidget):
         apply_children(root, None)
 
     def _animate_z(self, gitem, z):
+        """Set the z-value only when it actually changes."""
+        if gitem.zValue() == z:
+            return
         if isinstance(gitem, QGraphicsObject):
             anim = QPropertyAnimation(gitem, b"zValue", self)
             anim.setDuration(150)


### PR DESCRIPTION
## Summary
- fix infinite loop when assigning z-values during layer tree sync

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852e292364c8323b3fab6ac6e7510f8