### PR TITLE
Fix group layer order

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1053,7 +1053,11 @@ class CanvasWidget(QGraphicsView):
         items = [it for it in self.scene.selectedItems() if it is not self._frame_item]
         if len(items) <= 1:
             return None
+        # Preserve stacking order by sorting the items from bottom to top
+        items.sort(key=lambda it: it.zValue())
         group = self.scene.createItemGroup(items)
+        # Keep the group's z to match the highest child so layers don't bounce
+        group.setZValue(max(it.zValue() for it in items))
         group.setFlags(
             QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
         )


### PR DESCRIPTION
## Summary
- keep item stacking order when grouping
- set group z-value to match the topmost child

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6852e3b9073883239d2da1f3e62806d5