### PR TITLE
Fix layer z-order conflicts

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -391,7 +391,10 @@ class LayersWidget(QWidget):
         if not self.canvas:
             return
 
+        z_index = 0
+
         def apply_children(tparent, gparent):
+            nonlocal z_index
             for idx in range(tparent.childCount()):
                 child = tparent.child(idx)
                 gitem = child.data(0, Qt.UserRole)
@@ -399,7 +402,8 @@ class LayersWidget(QWidget):
                     target_parent = gparent if isinstance(gparent, QGraphicsItemGroup) else None
                     if gitem.parentItem() is not target_parent:
                         gitem.setParentItem(target_parent)
-                    self._animate_z(gitem, idx)
+                    self._animate_z(gitem, z_index)
+                    z_index += 1
                 apply_children(child, gitem)
 
         root = self.tree.invisibleRootItem()


### PR DESCRIPTION
## Summary
- ensure unique z index when applying tree hierarchy to the scene

## Testing
- `python -m py_compile pictocode/ui/layers_dock.py`


------
https://chatgpt.com/codex/tasks/task_e_685309f388a88323b1e2da187434dc94