### PR TITLE
Fix layer z-order conflicts

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -194,6 +194,9 @@ class LayersWidget(QWidget):
         root_item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsDropEnabled)
         root_item.setFirstColumnSpanned(True)
 
+        def _sort_z(item):
+            return self._z_anims.get(item, item.zValue())
+
         def add_item(gitem, parent=root_item):
             if gitem is getattr(canvas, "_frame_item", None):
                 return
@@ -213,11 +216,11 @@ class LayersWidget(QWidget):
             qitem.setText(2, "🔒" if locked else "🔓")
             if isinstance(gitem, QGraphicsItemGroup):
                 qitem.setExpanded(True)
-                for child in reversed(gitem.childItems()):
+                for child in sorted(gitem.childItems(), key=_sort_z):
                     add_item(child, qitem)
 
         # ajoute seulement les top-level (pas déjà dans un groupe)
-        for it in reversed(canvas.scene.items()):
+        for it in sorted(canvas.scene.items(), key=_sort_z):
             if it is getattr(canvas, "_frame_item", None):
                 continue
             if it.parentItem() is None:
@@ -391,7 +394,10 @@ class LayersWidget(QWidget):
         if not self.canvas:
             return
 
+        z_index = 0
+
         def apply_children(tparent, gparent):
+            nonlocal z_index
             for idx in range(tparent.childCount()):
                 child = tparent.child(idx)
                 gitem = child.data(0, Qt.UserRole)
@@ -399,7 +405,8 @@ class LayersWidget(QWidget):
                     target_parent = gparent if isinstance(gparent, QGraphicsItemGroup) else None
                     if gitem.parentItem() is not target_parent:
                         gitem.setParentItem(target_parent)
-                    self._animate_z(gitem, idx)
+                    self._animate_z(gitem, z_index)
+                    z_index += 1
                 apply_children(child, gitem)
 
         root = self.tree.invisibleRootItem()


### PR DESCRIPTION
## Summary
- ensure unique z index when applying tree hierarchy to the scene
- maintain stable layer order while z-value animations are running

## Testing
- `python -m py_compile pictocode/ui/layers_dock.py`


------
https://chatgpt.com/codex/tasks/task_e_685309f388a88323b1e2da187434dc94