### PR TITLE
Fix reparenting clearing item flags

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -405,6 +405,14 @@ class LayersWidget(QWidget):
                     target_parent = gparent if isinstance(gparent, QGraphicsItemGroup) else None
                     if gitem.parentItem() is not target_parent:
                         gitem.setParentItem(target_parent)
+                        gitem.setFlag(
+                            QGraphicsItem.ItemIsMovable,
+                            gitem.flags() & QGraphicsItem.ItemIsMovable,
+                        )
+                        gitem.setFlag(
+                            QGraphicsItem.ItemIsSelectable,
+                            gitem.flags() & QGraphicsItem.ItemIsSelectable,
+                        )
                     self._animate_z(gitem, z_index)
                     z_index += 1
                 apply_children(child, gitem)


### PR DESCRIPTION
## Summary
- preserve movability and selectability after reparenting graphics items

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. python /tmp/test_flags2.py`

------
https://chatgpt.com/codex/tasks/task_e_68530f84b1a883238ec01ed88f36934d