### PR TITLE
Resolve flake8 E501 violations

### DIFF
--- a/pictocode/__main__.py
+++ b/pictocode/__main__.py
@@ -14,7 +14,8 @@ def main():
     if os.name == "nt":
         import ctypes
 
-        ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)
+        ctypes.windll.user32.ShowWindow(
+            ctypes.windll.kernel32.GetConsoleWindow(), 0)
     app = QApplication(sys.argv)
     settings = QSettings("pictocode", "pictocode")
     show_splash = settings.value("show_splash", True, type=bool)

--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -161,10 +161,13 @@ class CanvasWidget(QGraphicsView):
             self.scene.removeItem(self._temp_item)
             self._temp_item = None
 
-    def new_document(self, width, height, unit, orientation, color_mode, dpi, name=""):
+    def new_document(
+        self, width, height, unit, orientation, color_mode, dpi, name=""
+    ):
         """
         Initialise un nouveau document selon les paramètres donnés.
-        width/height en unité choisie, orientation et dpi sont pris en compte ici.
+        width/height en unité choisie, orientation et dpi sont pris en
+        compte ici.
         """
         w = to_pixels(width, unit, dpi)
         h = to_pixels(height, unit, dpi)
@@ -264,14 +267,21 @@ class CanvasWidget(QGraphicsView):
         w = int(self._doc_rect.width())
         h = int(self._doc_rect.height())
         root = Element(
-            "svg", xmlns="http://www.w3.org/2000/svg", width=str(w), height=str(h)
+            "svg",
+            xmlns="http://www.w3.org/2000/svg",
+            width=str(w),
+            height=str(h),
         )
 
         for item in reversed(self.scene.items()):
             if item is self._frame_item:
                 continue
             cls = type(item).__name__
-            stroke = item.pen().color().name() if hasattr(item, "pen") else "#000000"
+            stroke = (
+                item.pen().color().name()
+                if hasattr(item, "pen")
+                else "#000000"
+            )
 
             if cls == "Rect":
                 r = item.rect()
@@ -312,11 +322,22 @@ class CanvasWidget(QGraphicsView):
                 )
             elif cls == "FreehandPath":
                 path = item.path()
-                pts = [path.elementAt(i) for i in range(path.elementCount())]
-                if len(pts) > 2 and pts[0].x == pts[-1].x and pts[0].y == pts[-1].y:
+                pts = [
+                    path.elementAt(i)
+                    for i in range(path.elementCount())
+                ]
+                if (
+                    len(pts) > 2
+                    and pts[0].x == pts[-1].x
+                    and pts[0].y == pts[-1].y
+                ):
                     points = " ".join(f"{p.x},{p.y}" for p in pts[:-1])
                     SubElement(
-                        root, "polygon", points=points, fill="none", stroke=stroke
+                        root,
+                        "polygon",
+                        points=points,
+                        fill="none",
+                        stroke=stroke,
                     )
                 else:
                     cmds = []
@@ -324,7 +345,11 @@ class CanvasWidget(QGraphicsView):
                         cmd = "M" if i == 0 else "L"
                         cmds.append(f"{cmd}{ept.x} {ept.y}")
                     SubElement(
-                        root, "path", d=" ".join(cmds), fill="none", stroke=stroke
+                        root,
+                        "path",
+                        d=" ".join(cmds),
+                        fill="none",
+                        stroke=stroke,
                     )
             elif cls == "TextItem":
                 SubElement(
@@ -413,7 +438,8 @@ class CanvasWidget(QGraphicsView):
                     self._temp_item.setOpacity(0.6)
                     self.scene.addItem(self._temp_item)
             elif self.current_tool == "text":
-                item = TextItem(scene_pos.x(), scene_pos.y(), "Texte", 12, self.pen_color)
+                item = TextItem(scene_pos.x(), scene_pos.y(),
+                                "Texte", 12, self.pen_color)
                 item.setZValue(self._new_item_z)
                 self.scene.addItem(item)
                 self._assign_layer_name(item)
@@ -445,7 +471,10 @@ class CanvasWidget(QGraphicsView):
                     path.lineTo(scene_pos)
                     self._polygon_item.setPath(path)
                     self._poly_preview_line.setLine(
-                        scene_pos.x(), scene_pos.y(), scene_pos.x(), scene_pos.y()
+                        scene_pos.x(),
+                        scene_pos.y(),
+                        scene_pos.x(),
+                        scene_pos.y(),
                     )
             elif self.current_tool == "freehand":
                 self._freehand_points = [scene_pos]
@@ -486,7 +515,10 @@ class CanvasWidget(QGraphicsView):
             self._poly_preview_line.setLine(
                 last.x(), last.y(), scene_pos.x(), scene_pos.y()
             )
-        elif self.current_tool == "freehand" and self._freehand_points is not None:
+        elif (
+            self.current_tool == "freehand"
+            and self._freehand_points is not None
+        ):
             self._freehand_points.append(scene_pos)
             if self._current_path_item:
                 path = self._current_path_item.path()
@@ -497,7 +529,8 @@ class CanvasWidget(QGraphicsView):
         elif self._temp_item and self._start_pos:
             x0, y0 = self._start_pos.x(), self._start_pos.y()
             if self.current_tool in ("rect", "ellipse"):
-                rect = QRectF(x0, y0, scene_pos.x() - x0, scene_pos.y() - y0).normalized()
+                rect = QRectF(x0, y0, scene_pos.x() - x0,
+                              scene_pos.y() - y0).normalized()
                 self._temp_item.setRect(
                     rect.x(), rect.y(), rect.width(), rect.height()
                 )
@@ -545,7 +578,8 @@ class CanvasWidget(QGraphicsView):
         elif self._temp_item and self._start_pos:
             x0, y0 = self._start_pos.x(), self._start_pos.y()
             if self.current_tool in ("rect", "ellipse"):
-                rect = QRectF(x0, y0, scene_pos.x() - x0, scene_pos.y() - y0).normalized()
+                rect = QRectF(x0, y0, scene_pos.x() - x0,
+                              scene_pos.y() - y0).normalized()
                 self._temp_item.setRect(
                     rect.x(), rect.y(), rect.width(), rect.height()
                 )
@@ -638,14 +672,17 @@ class CanvasWidget(QGraphicsView):
             item = items[0]
             if hasattr(item, "pen"):
                 act_color = QAction("Couleur du contour...", self)
-                act_color.triggered.connect(lambda: self._change_pen_color(item))
+                act_color.triggered.connect(
+                    lambda: self._change_pen_color(item))
                 menu.addAction(act_color)
                 act_width = QAction("Épaisseur du trait...", self)
-                act_width.triggered.connect(lambda: self._change_pen_width(item))
+                act_width.triggered.connect(
+                    lambda: self._change_pen_width(item))
                 menu.addAction(act_width)
             if hasattr(item, "brush"):
                 act_fill = QAction("Couleur de remplissage...", self)
-                act_fill.triggered.connect(lambda: self._change_brush_color(item))
+                act_fill.triggered.connect(
+                    lambda: self._change_brush_color(item))
                 menu.addAction(act_fill)
             act_delete = QAction("Supprimer", self)
             act_delete.triggered.connect(
@@ -859,7 +896,8 @@ class CanvasWidget(QGraphicsView):
         t = data.get("type")
         if t == "rect":
             item = Rect(
-                data["x"], data["y"], data["w"], data["h"], QColor(data["color"])
+                data["x"], data["y"], data["w"], data["h"], QColor(
+                    data["color"])
             )
             pen = item.pen()
             pen.setWidth(int(data.get("pen_width", pen.width())))
@@ -872,7 +910,8 @@ class CanvasWidget(QGraphicsView):
             item.setZValue(float(data.get("z", 0)))
         elif t == "ellipse":
             item = Ellipse(
-                data["x"], data["y"], data["w"], data["h"], QColor(data["color"])
+                data["x"], data["y"], data["w"], data["h"], QColor(
+                    data["color"])
             )
             pen = item.pen()
             pen.setWidth(int(data.get("pen_width", pen.width())))
@@ -885,7 +924,8 @@ class CanvasWidget(QGraphicsView):
             item.setZValue(float(data.get("z", 0)))
         elif t == "line":
             item = Line(
-                data["x1"], data["y1"], data["x2"], data["y2"], QColor(data["color"])
+                data["x1"], data["y1"], data["x2"], data["y2"], QColor(
+                    data["color"])
             )
             pen = item.pen()
             pen.setWidth(int(data.get("pen_width", pen.width())))
@@ -895,7 +935,8 @@ class CanvasWidget(QGraphicsView):
             item.setZValue(float(data.get("z", 0)))
         elif t == "path":
             pts = [QPointF(p[0], p[1]) for p in data.get("points", [])]
-            item = FreehandPath.from_points(pts, QColor(data.get("color", "black")))
+            item = FreehandPath.from_points(
+                pts, QColor(data.get("color", "black")))
             pen = item.pen()
             pen.setWidth(int(data.get("pen_width", pen.width())))
             item.setPen(pen)

--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -56,7 +56,8 @@ class ResizableMixin:
         self._start_rect = QRectF()
         self._start_item_pos = QPointF()
         self._start_center = QPointF()
-        self._active_handle = None  # 0: TL, 1: TR, 2: BR, 3: BL, 4: T, 5: R, 6: B, 7: L, 8: rotation
+        # 0: TL, 1: TR, 2: BR, 3: BL, 4: T, 5: R, 6: B, 7: L, 8: rotation
+        self._active_handle = None
         self._start_angle = 0.0
 
     # -- Geometry ----------------------------------------------------
@@ -104,7 +105,8 @@ class ResizableMixin:
         return path.united(extra)
 
     def _shape_path(self):
-        """Return a QPainterPath representing the pure shape (without handles)."""
+        """Return a QPainterPath representing the pure shape (without
+        handles)."""
         if hasattr(self, "path"):
             return QPainterPath(self.path())
         if hasattr(self, "line"):
@@ -172,7 +174,8 @@ class ResizableMixin:
                 QRectF(r.left() - s / 2, r.bottom() - s / 2, s, s),  # 3 BL
                 QRectF(r.center().x() - s / 2, r.top() - s / 2, s, s),  # 4 T
                 QRectF(r.right() - s / 2, r.center().y() - s / 2, s, s),  # 5 R
-                QRectF(r.center().x() - s / 2, r.bottom() - s / 2, s, s),  # 6 B
+                QRectF(r.center().x() - s / 2,
+                       r.bottom() - s / 2, s, s),  # 6 B
                 QRectF(r.left() - s / 2, r.center().y() - s / 2, s, s),  # 7 L
             ]
             rot_s = self.rotation_handle_size
@@ -210,7 +213,8 @@ class ResizableMixin:
             start_local = self.mapFromScene(self._start_scene_pos)
             current_local = self.mapFromScene(event.scenePos())
             delta_item = current_local - start_local
-            delta_scene = self.mapToScene(current_local) - self.mapToScene(start_local)
+            delta_scene = self.mapToScene(
+                current_local) - self.mapToScene(start_local)
 
             x = self._start_item_pos.x()
             y = self._start_item_pos.y()
@@ -256,8 +260,10 @@ class ResizableMixin:
             center = self._start_center
             start_vec = self._start_scene_pos - center
             current_vec = event.scenePos() - center
-            start_angle = math.degrees(math.atan2(start_vec.y(), start_vec.x()))
-            curr_angle = math.degrees(math.atan2(current_vec.y(), current_vec.x()))
+            start_angle = math.degrees(
+                math.atan2(start_vec.y(), start_vec.x()))
+            curr_angle = math.degrees(math.atan2(
+                current_vec.y(), current_vec.x()))
             self.setRotation(self._start_angle + curr_angle - start_angle)
             event.accept()
             return
@@ -431,7 +437,10 @@ class FreehandPath(ResizableMixin, SnapToGridMixin, QGraphicsPathItem):
     """
 
     def __init__(
-        self, path=None, pen_color: QColor = QColor("black"), pen_width: int = 2
+        self,
+        path=None,
+        pen_color: QColor = QColor("black"),
+        pen_width: int = 2,
     ):
         ResizableMixin.__init__(self)
         QGraphicsPathItem.__init__(self)

--- a/pictocode/ui/__init__.py
+++ b/pictocode/ui/__init__.py
@@ -6,4 +6,5 @@ from .title_bar import TitleBar
 from .project_tile import ProjectTile
 from .gradient_editor import GradientEditorDialog
 
-__all__ = ["MainWindow", "AnimatedMenu", "TitleBar", "ProjectTile", "GradientEditorDialog"]
+__all__ = ["MainWindow", "AnimatedMenu", "TitleBar",
+    "ProjectTile", "GradientEditorDialog"]

--- a/pictocode/ui/app_settings_dialog.py
+++ b/pictocode/ui/app_settings_dialog.py
@@ -59,7 +59,8 @@ class AppSettingsDialog(QDialog):
         self.accent_color = QColor(accent)
         self.color_edit = QLineEdit(self.accent_color.name())
         self.color_edit.setReadOnly(True)
-        self.color_edit.mousePressEvent = lambda e: self._choose_color("accent")
+        self.color_edit.mousePressEvent = lambda e: self._choose_color(
+            "accent")
         form.addRow("Couleur d'accent :", self.color_edit)
 
         # Global font size
@@ -72,7 +73,8 @@ class AppSettingsDialog(QDialog):
         self.menu_color = QColor(menu_color or self.accent_color)
         self.menu_color_edit = QLineEdit(self.menu_color.name())
         self.menu_color_edit.setReadOnly(True)
-        self.menu_color_edit.mousePressEvent = lambda e: self._choose_color("menu")
+        self.menu_color_edit.mousePressEvent = lambda e: self._choose_color(
+            "menu")
         form.addRow("Couleur menu :", self.menu_color_edit)
 
         self.toolbar_color = QColor(toolbar_color or self.accent_color)
@@ -86,7 +88,8 @@ class AppSettingsDialog(QDialog):
         self.dock_color = QColor(dock_color or self.accent_color)
         self.dock_color_edit = QLineEdit(self.dock_color.name())
         self.dock_color_edit.setReadOnly(True)
-        self.dock_color_edit.mousePressEvent = lambda e: self._choose_color("dock")
+        self.dock_color_edit.mousePressEvent = lambda e: self._choose_color(
+            "dock")
         form.addRow("Couleur inspecteur :", self.dock_color_edit)
 
         # Per-element font sizes
@@ -118,7 +121,8 @@ class AppSettingsDialog(QDialog):
         self.handle_color = QColor(handle_color or Qt.black)
         self.handle_color_edit = QLineEdit(self.handle_color.name())
         self.handle_color_edit.setReadOnly(True)
-        self.handle_color_edit.mousePressEvent = lambda e: self._choose_color("handle")
+        self.handle_color_edit.mousePressEvent = lambda e: self._choose_color(
+            "handle")
         form.addRow("Couleur poignées :", self.handle_color_edit)
 
         self.rotation_offset_spin = QSpinBox()
@@ -127,9 +131,12 @@ class AppSettingsDialog(QDialog):
         form.addRow("Décalage rotation :", self.rotation_offset_spin)
 
         self.rotation_handle_color = QColor(rotation_handle_color or Qt.red)
-        self.rotation_handle_color_edit = QLineEdit(self.rotation_handle_color.name())
+        self.rotation_handle_color_edit = QLineEdit(
+            self.rotation_handle_color.name())
         self.rotation_handle_color_edit.setReadOnly(True)
-        self.rotation_handle_color_edit.mousePressEvent = lambda e: self._choose_color("rotation_handle")
+        self.rotation_handle_color_edit.mousePressEvent = (
+            lambda e: self._choose_color("rotation_handle")
+        )
         form.addRow("Couleur rotation :", self.rotation_handle_color_edit)
 
         self.autosave_chk = QCheckBox()

--- a/pictocode/ui/gradient_editor.py
+++ b/pictocode/ui/gradient_editor.py
@@ -86,7 +86,8 @@ class GradientEditorDialog(QDialog):
         slider_layout.addWidget(self.slider2)
         layout.addLayout(slider_layout)
 
-        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)

--- a/pictocode/ui/home_page.py
+++ b/pictocode/ui/home_page.py
@@ -61,7 +61,8 @@ class HomePage(QWidget):
     - Double-clic sur un projet pour l’ouvrir
     """
 
-    PROJECTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Projects")
+    PROJECTS_DIR = os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), "Projects")
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -94,9 +95,11 @@ class HomePage(QWidget):
         rec_col.addWidget(recent_label)
         self.recent_list = ProjectList(self, "recent")
         self.recent_list.setObjectName("recent_list")
-        self.recent_list.itemDoubleClicked.connect(self._on_project_double_click)
+        self.recent_list.itemDoubleClicked.connect(
+            self._on_project_double_click)
         self.recent_list.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.recent_list.customContextMenuRequested.connect(self._on_recent_menu)
+        self.recent_list.customContextMenuRequested.connect(
+            self._on_recent_menu)
         rec_col.addWidget(self.recent_list)
         body.addLayout(rec_col, 1)
 
@@ -121,9 +124,11 @@ class HomePage(QWidget):
         self.template_list.addItem("A4 Portrait (210×297 mm)")
         self.template_list.addItem("A4 Paysage (297×210 mm)")
         self.template_list.addItem("HD 1080p (1920×1080 px)")
-        self.template_list.itemDoubleClicked.connect(self._on_template_double_click)
+        self.template_list.itemDoubleClicked.connect(
+            self._on_template_double_click)
         self.template_list.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.template_list.customContextMenuRequested.connect(self._on_template_menu)
+        self.template_list.customContextMenuRequested.connect(
+            self._on_template_menu)
         right_col.addWidget(self.template_list)
 
         body.addLayout(right_col, 1)
@@ -180,7 +185,9 @@ class HomePage(QWidget):
             self.fav_list, self.parent.favorite_projects, "(Aucun favori)"
         )
         recent = self._populate_list(
-            self.recent_list, self.parent.recent_projects, "(Aucun projet récent)"
+            self.recent_list,
+            self.parent.recent_projects,
+            "(Aucun projet récent)",
         )
         templates = self._populate_list(
             self.template_list, self.parent.template_projects, ""
@@ -198,7 +205,9 @@ class HomePage(QWidget):
             self.parent.template_projects = templates
             self.parent.settings.setValue("template_projects", templates)
 
-    def _populate_list(self, widget: QListWidget, paths: list, empty_text: str):
+    def _populate_list(
+        self, widget: QListWidget, paths: list, empty_text: str
+    ):
         widget.clear()
         style = self.style()
         valid = []
@@ -265,7 +274,8 @@ class HomePage(QWidget):
         """Ouvre le projet sélectionné."""
         path = item.data(Qt.UserRole)
         if not path or not os.path.exists(path):
-            QMessageBox.warning(self, "Erreur", "Impossible de trouver le projet.")
+            QMessageBox.warning(
+                self, "Erreur", "Impossible de trouver le projet.")
             return
 
         # Charge les paramètres depuis le fichier
@@ -287,7 +297,8 @@ class HomePage(QWidget):
                 with open(path, "r", encoding="utf-8") as f:
                     data = json.load(f)
         except Exception as e:
-            QMessageBox.critical(self, "Erreur", f"Échec de lecture de {path} :\n{e}")
+            QMessageBox.critical(
+                self, "Erreur", f"Échec de lecture de {path} :\n{e}")
             return
 
         # Sépare métadonnées et formes
@@ -335,7 +346,8 @@ class HomePage(QWidget):
             dlg.height_spin.setValue(params.get("height", 600))
             dlg.unit_combo.setCurrentText(params.get("unit", "px"))
             dlg.orient_combo.setCurrentText(
-                "Portrait" if params.get("orientation", "portrait") == "portrait" else "Paysage"
+                "Portrait" if params.get(
+                    "orientation", "portrait") == "portrait" else "Paysage"
             )
             dlg.color_combo.setCurrentText(params.get("color_mode", "RGB"))
             dlg.dpi_spin.setValue(params.get("dpi", 72))
@@ -390,5 +402,6 @@ class HomePage(QWidget):
         if menu.exec_(self.template_list.mapToGlobal(pos)) == act:
             if path in self.parent.template_projects:
                 self.parent.template_projects.remove(path)
-                self.parent.settings.setValue("template_projects", self.parent.template_projects)
+                self.parent.settings.setValue(
+                    "template_projects", self.parent.template_projects)
                 self.populate_lists()

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -95,26 +95,36 @@ class Inspector(QWidget):
                     0, 0, self._item.rect().width(), int(val)
                 ),
             ),
-            (self.rotation_field, lambda val: self._item.setRotation(int(val))),
+            (
+                self.rotation_field,
+                lambda val: self._item.setRotation(int(val)),
+            ),
             (self.z_field, lambda val: self._item.setZValue(int(val))),
             (self.border_field, self._set_pen_width),
-            (self.opacity_field, lambda val: self._item.setOpacity(int(val)/100)),
+            (
+                self.opacity_field,
+                lambda val: self._item.setOpacity(int(val) / 100),
+            ),
             (self.var_field, self._set_var_name),
             (self.align_field, self._set_alignment),
-            (self.text_field, lambda val: self._item.setPlainText(val) if hasattr(self._item, 'setPlainText') else None),
+            (self.text_field, lambda val: self._item.setPlainText(
+                val) if hasattr(self._item, 'setPlainText') else None),
             (self.font_field, lambda val: self._set_font_size(int(val))),
         ):
             if hasattr(fld, "valueChanged"):
                 fld.valueChanged.connect(
-                    lambda _val, fld=fld, st=setter: self._update_field(fld, st)
+                    lambda _val, fld=fld, st=setter: self._update_field(
+                        fld, st)
                 )
             elif hasattr(fld, "textEdited"):
                 fld.textEdited.connect(
-                    lambda _val, fld=fld, st=setter: self._update_field(fld, st)
+                    lambda _val, fld=fld, st=setter: self._update_field(
+                        fld, st)
                 )
             elif isinstance(fld, QComboBox):
                 fld.currentIndexChanged.connect(
-                    lambda _idx, fld=fld, st=setter: self._update_field(fld, st)
+                    lambda _idx, fld=fld, st=setter: self._update_field(
+                        fld, st)
                 )
 
         # Choix de couleur handled by clicked signal
@@ -170,7 +180,8 @@ class Inspector(QWidget):
                 if stops:
                     self._update_gradient_button(stops[0][1], stops[-1][1])
                 else:
-                    self._update_gradient_button(QColor("white"), QColor("black"))
+                    self._update_gradient_button(
+                        QColor("white"), QColor("black"))
             else:
                 self._update_gradient_button(QColor("white"), QColor("black"))
             self._update_fill_button(brush.color().name())
@@ -291,7 +302,8 @@ class Inspector(QWidget):
 
     def _update_gradient_button(self, start: QColor, end: QColor):
         self.gradient_btn.setStyleSheet(
-            "background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 %s, stop:1 %s);"
+            "background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 %s,"
+            " stop:1 %s);"
             % (start.name(), end.name())
         )
 

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -19,7 +19,14 @@ from .animated_menu import AnimatedMenu
 class LayersTreeWidget(QTreeWidget):
     """QTreeWidget with custom drag preview highlighting."""
 
-    def __init__(self, parent=None, *, drop_color: QColor | None = None, group_color: QColor | None = None, **kwargs):
+    def __init__(
+        self,
+        parent=None,
+        *,
+        drop_color: QColor | None = None,
+        group_color: QColor | None = None,
+        **kwargs,
+    ):
         super().__init__(parent, **kwargs)
         self._parent = parent
         pal = self.palette()
@@ -33,13 +40,13 @@ class LayersTreeWidget(QTreeWidget):
 
     def _clear_highlight(self):
         if self._highlight_item:
-            # The QTreeWidgetItem may have been removed from the tree during a
-            # drop operation. When this happens Qt deletes the underlying C++
+            # The QTreeWidgetItem may have been removed from the tree during
+            # a drop operation. When this happens Qt deletes the underlying C++
             # object and calling methods on it raises a RuntimeError. Guard by
             # checking that the item still belongs to a tree before clearing
-            # its background colors. The call to ``treeWidget`` itself can raise
-            # ``RuntimeError`` if the wrapped C++ object has been deleted, so we
-            # also protect against that case.
+            # its background colors. The call to ``treeWidget`` itself can
+            # raise ``RuntimeError`` if the wrapped C++ object has been
+            # deleted, so we also protect against that case.
             try:
                 if self._highlight_item.treeWidget() is not None:
                     for c in range(self.columnCount()):
@@ -54,9 +61,16 @@ class LayersTreeWidget(QTreeWidget):
         item = self.itemAt(event.pos())
         pos = self.dropIndicatorPosition()
 
-        if pos in (QAbstractItemView.AboveItem, QAbstractItemView.BelowItem) and item:
+        if (
+            pos in (QAbstractItemView.AboveItem, QAbstractItemView.BelowItem)
+            and item
+        ):
             rect = self.visualItemRect(item)
-            y = rect.top() if pos == QAbstractItemView.AboveItem else rect.bottom()
+            y = (
+                rect.top()
+                if pos == QAbstractItemView.AboveItem
+                else rect.bottom()
+            )
             self._drop_line.setGeometry(0, y, self.viewport().width(), 2)
             self._drop_line.show()
         else:
@@ -186,7 +200,8 @@ class LayersWidget(QWidget):
         if not canvas:
             return
 
-        project_name = getattr(canvas, "current_meta", {}).get("name") or "Projet"
+        project_name = getattr(canvas, "current_meta",
+                               {}).get("name") or "Projet"
         root_item = QTreeWidgetItem(self.tree)
         root_item.setText(0, project_name)
         root_item.setData(0, Qt.UserRole, None)
@@ -367,7 +382,8 @@ class LayersWidget(QWidget):
     def _handle_tree_drop(self, event):
         target_item = self.tree.itemAt(event.pos())
         drop_pos = self.tree.dropIndicatorPosition()
-        selected = [it.data(0, Qt.UserRole) for it in self.tree.selectedItems()]
+        selected = [it.data(0, Qt.UserRole)
+                            for it in self.tree.selectedItems()]
 
         if (
             target_item
@@ -377,8 +393,13 @@ class LayersWidget(QWidget):
             and self.canvas
         ):
             target_gitem = target_item.data(0, Qt.UserRole)
-            if target_gitem and not isinstance(target_gitem, QGraphicsItemGroup):
-                items = [target_gitem] + sorted(selected, key=lambda g: g.zValue())
+            if (
+                target_gitem
+                and not isinstance(target_gitem, QGraphicsItemGroup)
+            ):
+                items = [target_gitem] + sorted(
+                    selected, key=lambda g: g.zValue()
+                )
                 group = self.canvas.group_selected(items, sort_items=False)
                 if group:
                     event.accept()
@@ -402,7 +423,8 @@ class LayersWidget(QWidget):
                 child = tparent.child(idx)
                 gitem = child.data(0, Qt.UserRole)
                 if gitem:
-                    target_parent = gparent if isinstance(gparent, QGraphicsItemGroup) else None
+                    target_parent = gparent if isinstance(
+                        gparent, QGraphicsItemGroup) else None
                     if gitem.parentItem() is not target_parent:
                         gitem.setParentItem(target_parent)
                     self._animate_z(gitem, z_index)
@@ -410,7 +432,10 @@ class LayersWidget(QWidget):
                 apply_children(child, gitem)
 
         root = self.tree.invisibleRootItem()
-        if root.childCount() == 1 and root.child(0).data(0, Qt.UserRole) is None:
+        if (
+            root.childCount() == 1
+            and root.child(0).data(0, Qt.UserRole) is None
+        ):
             root = root.child(0)
         apply_children(root, None)
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -29,7 +29,8 @@ from .shortcut_settings_dialog import ShortcutSettingsDialog
 from .layers_dock import LayersWidget
 from .imports_dock import ImportsWidget
 
-PROJECTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Projects")
+PROJECTS_DIR = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "Projects")
 
 
 class MainWindow(QMainWindow):
@@ -65,12 +66,18 @@ class MainWindow(QMainWindow):
 
         # Paramètres de l'application
         self.settings = QSettings("pictocode", "pictocode")
-        self.favorite_projects = self.settings.value("favorite_projects", [], type=list)
-        self.recent_projects = self.settings.value("recent_projects", [], type=list)
-        self.imported_images = self.settings.value("imported_images", [], type=list)
-        self.template_projects = self.settings.value("template_projects", [], type=list)
-        self.autosave_enabled = self.settings.value("autosave_enabled", False, type=bool)
-        self.autosave_interval = int(self.settings.value("autosave_interval", 5))
+        self.favorite_projects = self.settings.value(
+            "favorite_projects", [], type=list)
+        self.recent_projects = self.settings.value(
+            "recent_projects", [], type=list)
+        self.imported_images = self.settings.value(
+            "imported_images", [], type=list)
+        self.template_projects = self.settings.value(
+            "template_projects", [], type=list)
+        self.autosave_enabled = self.settings.value(
+            "autosave_enabled", False, type=bool)
+        self.autosave_interval = int(
+            self.settings.value("autosave_interval", 5))
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:
@@ -163,7 +170,8 @@ class MainWindow(QMainWindow):
 
         # Paramètres de thème et raccourcis
         self.current_theme = self.settings.value("theme", "Light")
-        self.accent_color = QColor(self.settings.value("accent_color", "#0078d7"))
+        self.accent_color = QColor(
+            self.settings.value("accent_color", "#0078d7"))
         self.font_size = int(self.settings.value("font_size", 10))
         self.menu_color = QColor(
             self.settings.value("menu_color", self.accent_color.name())
@@ -180,15 +188,18 @@ class MainWindow(QMainWindow):
         self.flag_inactive_color = QColor(
             self.settings.value("flag_inactive_color", "#3a3f44")
         )
-        self.menu_font_size = int(self.settings.value("menu_font_size", self.font_size))
+        self.menu_font_size = int(self.settings.value(
+            "menu_font_size", self.font_size))
         self.toolbar_font_size = int(
             self.settings.value("toolbar_font_size", self.font_size)
         )
-        self.dock_font_size = int(self.settings.value("dock_font_size", self.font_size))
+        self.dock_font_size = int(self.settings.value(
+            "dock_font_size", self.font_size))
         self.show_splash = self.settings.value("show_splash", True, type=bool)
         self.handle_size = int(self.settings.value("handle_size", 12))
         self.rotation_offset = int(self.settings.value("rotation_offset", 20))
-        self.handle_color = QColor(self.settings.value("handle_color", "#000000"))
+        self.handle_color = QColor(
+            self.settings.value("handle_color", "#000000"))
         self.rotation_handle_color = QColor(
             self.settings.value("rotation_handle_color", "#ff0000")
         )
@@ -499,7 +510,8 @@ class MainWindow(QMainWindow):
                 }
                 self.open_project(path, params, data.get("shapes", []))
             except Exception as e:
-                QMessageBox.critical(self, "Erreur", f"Impossible d'ouvrir : {e}")
+                QMessageBox.critical(
+                    self, "Erreur", f"Impossible d'ouvrir : {e}")
 
     def open_project(self, path, params, shapes=None):
         """Charge un projet existant (optionnellement avec formes)."""
@@ -537,8 +549,12 @@ class MainWindow(QMainWindow):
 
                 images = []
                 for shp in data.get("shapes", []):
-                    if shp.get("type") == "image" and os.path.exists(shp["path"]):
-                        images.append((shp["path"], os.path.basename(shp["path"])))
+                    if (
+                        shp.get("type") == "image"
+                        and os.path.exists(shp["path"])
+                    ):
+                        images.append(
+                            (shp["path"], os.path.basename(shp["path"])))
                         shp["path"] = f"images/{os.path.basename(shp['path'])}"
 
                 with zipfile.ZipFile(self.current_project_path, "w") as zf:
@@ -551,7 +567,9 @@ class MainWindow(QMainWindow):
                     for src, name in images:
                         zf.write(src, f"images/{name}")
             else:
-                with open(self.current_project_path, "w", encoding="utf-8") as f:
+                with open(
+                    self.current_project_path, "w", encoding="utf-8"
+                ) as f:
                     json.dump(data, f, indent=2, ensure_ascii=False)
                 # also save preview
                 thumb = os.path.splitext(self.current_project_path)[0] + ".png"
@@ -561,10 +579,15 @@ class MainWindow(QMainWindow):
             self.add_recent_project(self.current_project_path)
             self.home.populate_lists()
         except Exception as e:
-            QMessageBox.critical(self, "Erreur", f"Impossible d'enregistrer : {e}")
+            QMessageBox.critical(
+                self, "Erreur", f"Impossible d'enregistrer : {e}")
 
     def _autosave(self):
-        if self.autosave_enabled and self.current_project_path and self.unsaved_changes:
+        if (
+            self.autosave_enabled
+            and self.current_project_path
+            and self.unsaved_changes
+        ):
             self.save_project()
 
     def save_as_project(self):
@@ -622,7 +645,8 @@ class MainWindow(QMainWindow):
                 with open(path, "w", encoding="utf-8") as f:
                     f.write(code)
             except Exception as e:
-                QMessageBox.critical(self, "Erreur", f"Impossible d'exporter : {e}")
+                QMessageBox.critical(
+                    self, "Erreur", f"Impossible d'exporter : {e}")
 
     def back_to_home(self):
         if not self.maybe_save():
@@ -700,7 +724,12 @@ class MainWindow(QMainWindow):
         from PyQt5.QtWidgets import QInputDialog
 
         size, ok = QInputDialog.getInt(
-            self, "Taille de la grille", "Pixels :", self.canvas.grid_size, 1, 200
+            self,
+            "Taille de la grille",
+            "Pixels :",
+            self.canvas.grid_size,
+            1,
+            200,
         )
         if ok:
             self.canvas.set_grid_size(size)
@@ -791,7 +820,8 @@ class MainWindow(QMainWindow):
 
     def open_shortcut_settings(self):
         current = {
-            name: act.shortcut().toString() for name, act in self.actions.items()
+            name: act.shortcut().toString()
+            for name, act in self.actions.items()
         }
         dlg = ShortcutSettingsDialog(current, self)
         if dlg.exec_() == QDialog.Accepted:
@@ -844,7 +874,8 @@ class MainWindow(QMainWindow):
         flag_active: QColor | None = None,
         flag_inactive: QColor | None = None,
     ):
-        """Applique un thème clair ou sombre ainsi que des réglages personnalisés."""
+        """Applique un thème clair ou sombre ainsi que des réglages
+        personnalisés."""
         app = QApplication.instance()
         accent = accent or self.accent_color
         font_size = font_size or self.font_size
@@ -869,13 +900,15 @@ class MainWindow(QMainWindow):
             pal.setColor(QPalette.Button, QColor(53, 53, 53))
             pal.setColor(QPalette.ButtonText, Qt.white)
             pal.setColor(QPalette.Highlight, accent)
-            pal.setColor(QPalette.HighlightedText, QColor(get_contrast_color(accent)))
+            pal.setColor(QPalette.HighlightedText,
+                         QColor(get_contrast_color(accent)))
             app.setPalette(pal)
             app.setStyle("Fusion")
         else:
             pal = app.style().standardPalette()
             pal.setColor(QPalette.Highlight, accent)
-            pal.setColor(QPalette.HighlightedText, QColor(get_contrast_color(accent)))
+            pal.setColor(QPalette.HighlightedText,
+                         QColor(get_contrast_color(accent)))
             app.setPalette(pal)
             app.setStyle("Fusion")
 
@@ -891,16 +924,56 @@ class MainWindow(QMainWindow):
         menu_fg = get_contrast_color(menu_color)
 
         self.setStyleSheet(
-            f"QToolBar {{ background: {toolbar_color.name()}; color: {tb_text}; font-size: {toolbar_font_size}pt; }}\n"
-            f"QMenuBar {{ background: transparent; font-size: {menu_font_size}pt; padding: 2px; }}\n"
-            f"QMenuBar::item {{ background: {inactive.name()}; color: {menu_text}; padding: 4px 8px; margin: 0 2px; border-top-left-radius:4px; border-top-right-radius:4px; }}\n"
-            f"QMenuBar::item:selected {{ background: {active.name()}; margin-top: 2px; }}\n"
-            f"QMenuBar::item:pressed {{ background: {active.name()}; margin-top: 2px; }}\n"
-            f"QWidget#title_bar {{ background: {toolbar_color.name()}; color: {tb_text}; font-size: {toolbar_font_size}pt; }}\n"
-            f"QWidget#title_bar QPushButton {{ border: none; background: transparent; color: {tb_text}; padding: 4px; }}\n"
-            f"QWidget#title_bar QPushButton:hover {{ background: {toolbar_color.darker(110).name()}; }}\n"
-            f"QMenu {{ background-color: {menu_color.name()}; color: {menu_fg}; border-radius: 6px; }}\n"
-            f"QMenu::item:selected {{ background-color: {menu_color.darker(130).name()}; }}"
+            f"""
+            QToolBar {{
+                background: {toolbar_color.name()};
+                color: {tb_text};
+                font-size: {toolbar_font_size}pt;
+            }}
+            QMenuBar {{
+                background: transparent;
+                font-size: {menu_font_size}pt;
+                padding: 2px;
+            }}
+            QMenuBar::item {{
+                background: {inactive.name()};
+                color: {menu_text};
+                padding: 4px 8px;
+                margin: 0 2px;
+                border-top-left-radius:4px;
+                border-top-right-radius:4px;
+            }}
+            QMenuBar::item:selected {{
+                background: {active.name()};
+                margin-top: 2px;
+            }}
+            QMenuBar::item:pressed {{
+                background: {active.name()};
+                margin-top: 2px;
+            }}
+            QWidget#title_bar {{
+                background: {toolbar_color.name()};
+                color: {tb_text};
+                font-size: {toolbar_font_size}pt;
+            }}
+            QWidget#title_bar QPushButton {{
+                border: none;
+                background: transparent;
+                color: {tb_text};
+                padding: 4px;
+            }}
+            QWidget#title_bar QPushButton:hover {{
+                background: {toolbar_color.darker(110).name()};
+            }}
+            QMenu {{
+                background-color: {menu_color.name()};
+                color: {menu_fg};
+                border-radius: 6px;
+            }}
+            QMenu::item:selected {{
+                background-color: {menu_color.darker(130).name()};
+            }}
+            """
         )
         self.inspector_dock.setStyleSheet(
             f"QDockWidget {{ background: {dock_color.name()}; }}"
@@ -910,7 +983,8 @@ class MainWindow(QMainWindow):
             f"font-size: {dock_font_size}pt;"
         )
         for dock in (self.layers_dock, self.imports_dock):
-            dock.setStyleSheet(f"QDockWidget {{ background: {dock_color.name()}; }}")
+            dock.setStyleSheet(
+                f"QDockWidget {{ background: {dock_color.name()}; }}")
         for widget in (self.layers, self.imports):
             widget.setStyleSheet(f"font-size: {dock_font_size}pt;")
             if hasattr(widget, "apply_theme"):

--- a/pictocode/ui/project_tile.py
+++ b/pictocode/ui/project_tile.py
@@ -5,7 +5,14 @@ from PyQt5.QtCore import Qt
 class ProjectTile(QWidget):
     """Widget affichant une miniature de projet avec un overlay au survol."""
 
-    def __init__(self, icon: QIcon, title: str, width=128, height=None, parent=None):
+    def __init__(
+        self,
+        icon: QIcon,
+        title: str,
+        width=128,
+        height=None,
+        parent=None,
+    ):
         super().__init__(parent)
         self._width = int(width)
         self._height = int(height or width)

--- a/pictocode/ui/shortcut_settings_dialog.py
+++ b/pictocode/ui/shortcut_settings_dialog.py
@@ -36,5 +36,6 @@ class ShortcutSettingsDialog(QDialog):
 
     def get_shortcuts(self) -> dict[str, str]:
         return {
-            name: edit.keySequence().toString() for name, edit in self._edits.items()
+            name: edit.keySequence().toString()
+            for name, edit in self._edits.items()
         }

--- a/pictocode/ui/title_bar.py
+++ b/pictocode/ui/title_bar.py
@@ -47,14 +47,20 @@ class TitleBar(QWidget):
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
-            handle = self.window().windowHandle() if hasattr(self.window(), "windowHandle") else None
+            handle = (
+                self.window().windowHandle()
+                if hasattr(self.window(), "windowHandle")
+                else None
+            )
             if handle:
                 try:
                     self._using_sys_move = handle.startSystemMove()
                 except Exception:
                     self._using_sys_move = False
             if not self._using_sys_move:
-                self._mouse_pos = event.globalPos() - self._parent.frameGeometry().topLeft()
+                self._mouse_pos = (
+                    event.globalPos() - self._parent.frameGeometry().topLeft()
+                )
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):

--- a/pictocode/ui/toolbar.py
+++ b/pictocode/ui/toolbar.py
@@ -67,7 +67,10 @@ class Toolbar(QToolBar):
         from PyQt5.QtWidgets import QFileDialog
 
         path, _ = QFileDialog.getOpenFileName(
-            self.parent(), "Importer une image", "", "Images (*.png *.jpg *.jpeg *.bmp *.gif)"
+            self.parent(),
+            "Importer une image",
+            "",
+            "Images (*.png *.jpg *.jpeg *.bmp *.gif)",
         )
         if path:
             item = self.canvas.insert_image(path)

--- a/pictocode/ui/windows_panel.py
+++ b/pictocode/ui/windows_panel.py
@@ -12,7 +12,12 @@ class WindowsPanel(QWidget):
         self.chk_props = QCheckBox('Propriétés')
         self.chk_toolbar = QCheckBox("Barre d'outils")
         self.chk_imports = QCheckBox('Imports')
-        for chk in (self.chk_layers, self.chk_props, self.chk_toolbar, self.chk_imports):
+        for chk in (
+            self.chk_layers,
+            self.chk_props,
+            self.chk_toolbar,
+            self.chk_imports,
+        ):
             layout.addWidget(chk)
 
         self.chk_layers.stateChanged.connect(

--- a/pictocode/utils.py
+++ b/pictocode/utils.py
@@ -13,7 +13,8 @@ def color_to_hex(qcolor):
 
 
 def get_contrast_color(qcolor):
-    """Return '#000000' or '#ffffff' depending on brightness for readability."""
+    """Return '#000000' or '#ffffff' depending on brightness for
+    readability."""
     from PyQt5.QtGui import QColor
 
     color = QColor(qcolor)
@@ -30,7 +31,10 @@ def generate_pycode(shapes):
         "    QGraphicsLineItem, QGraphicsPathItem, QGraphicsPolygonItem,",
         "    QGraphicsTextItem",
         ")",
-        "from PyQt5.QtGui import QPen, QBrush, QColor, QPainterPath, QPolygonF",
+        (
+            "from PyQt5.QtGui import QPen, QBrush, QColor, QPainterPath, "
+            "QPolygonF"
+        ),
         "from PyQt5.QtCore import QPointF",
         "",
         "scene = QGraphicsScene()",
@@ -44,7 +48,8 @@ def generate_pycode(shapes):
         if cls == "Rect":
             r = shp.rect()
             lines.append(
-                f"rect{i} = QGraphicsRectItem({r.x()}, {r.y()}, {r.width()}, {r.height()})"
+                f"rect{i} = QGraphicsRectItem("
+                f"{r.x()}, {r.y()}, {r.width()}, {r.height()})"
             )
             color = shp.pen().color().name()
             width = shp.pen().width()
@@ -62,11 +67,13 @@ def generate_pycode(shapes):
         elif cls == "Ellipse":
             e = shp.rect()
             lines.append(
-                f"ellipse{i} = QGraphicsEllipseItem({e.x()}, {e.y()}, {e.width()}, {e.height()})"
+                f"ellipse{i} = QGraphicsEllipseItem("
+                f"{e.x()}, {e.y()}, {e.width()}, {e.height()})"
             )
             color = shp.pen().color().name()
             width = shp.pen().width()
-            lines.append(f"ellipse{i}.setPen(QPen(QColor('{color}'), {width}))")
+            lines.append(
+                f"ellipse{i}.setPen(QPen(QColor('{color}'), {width}))")
             if shp.brush().style() != 0:
                 fill = shp.brush().color().name()
                 lines.append(f"ellipse{i}.setBrush(QBrush(QColor('{fill}')))")
@@ -80,7 +87,8 @@ def generate_pycode(shapes):
         elif cls == "Line":
             line = shp.line()
             lines.append(
-                f"line{i} = QGraphicsLineItem({line.x1()}, {line.y1()}, {line.x2()}, {line.y2()})"
+                f"line{i} = QGraphicsLineItem("
+                f"{line.x1()}, {line.y1()}, {line.x2()}, {line.y2()})"
             )
             color = shp.pen().color().name()
             width = shp.pen().width()
@@ -95,7 +103,8 @@ def generate_pycode(shapes):
         elif cls == "FreehandPath":
             path = shp.path()
             pts = [path.elementAt(j) for j in range(path.elementCount())]
-            is_poly = len(pts) > 2 and pts[0].x == pts[-1].x and pts[0].y == pts[-1].y
+            is_poly = len(
+                pts) > 2 and pts[0].x == pts[-1].x and pts[0].y == pts[-1].y
             if is_poly:
                 lines.append(f"poly{i} = QPolygonF([")
                 for p in pts[:-1]:
@@ -104,10 +113,12 @@ def generate_pycode(shapes):
                 lines.append(f"poly_item{i} = QGraphicsPolygonItem(poly{i})")
                 color = shp.pen().color().name()
                 width = shp.pen().width()
-                lines.append(f"poly_item{i}.setPen(QPen(QColor('{color}'), {width}))")
+                lines.append(
+                    f"poly_item{i}.setPen(QPen(QColor('{color}'), {width}))")
                 if shp.brush().style() != 0:
                     fill = shp.brush().color().name()
-                    lines.append(f"poly_item{i}.setBrush(QBrush(QColor('{fill}')))")
+                    lines.append(
+                        f"poly_item{i}.setBrush(QBrush(QColor('{fill}')))")
                 lines.append(f"poly_item{i}.setPos({shp.x()}, {shp.y()})")
                 if shp.rotation() != 0:
                     lines.append(f"poly_item{i}.setRotation({shp.rotation()})")
@@ -122,10 +133,12 @@ def generate_pycode(shapes):
                 lines.append(f"path_item{i} = QGraphicsPathItem(path{i})")
                 color = shp.pen().color().name()
                 width = shp.pen().width()
-                lines.append(f"path_item{i}.setPen(QPen(QColor('{color}'), {width}))")
+                lines.append(
+                    f"path_item{i}.setPen(QPen(QColor('{color}'), {width}))")
                 if shp.brush().style() != 0:
                     fill = shp.brush().color().name()
-                    lines.append(f"path_item{i}.setBrush(QBrush(QColor('{fill}')))")
+                    lines.append(
+                        f"path_item{i}.setBrush(QBrush(QColor('{fill}')))")
                 lines.append(f"path_item{i}.setPos({shp.x()}, {shp.y()})")
                 if shp.rotation() != 0:
                     lines.append(f"path_item{i}.setRotation({shp.rotation()})")


### PR DESCRIPTION
## Summary
- format long constructor lines in UI widgets
- wrap long comments and statements for readability
- reflow style sheet strings in the main window
- split long f-strings in utils

## Testing
- `flake8 --select=E501 pictocode`

------
https://chatgpt.com/codex/tasks/task_e_68530f83e1e883239bfab430404b8935