### PR TITLE
Enhance layer outliner

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QGraphicsItemGroup,
     QHeaderView,
     QFrame,
+    QStyle,
 )
 from PyQt5.QtCore import Qt, QPropertyAnimation
 from PyQt5.QtWidgets import QGraphicsObject
@@ -123,7 +124,7 @@ class LayersWidget(QWidget):
         self.canvas = None
         self.tree = LayersTreeWidget(self)
         self.tree.setColumnCount(3)
-        self.tree.setHeaderLabels(["Nom", "👁", "🔒"])
+        self.tree.setHeaderLabels(["Nom", "Vis", "Lock"])
         self.tree.setSelectionMode(QAbstractItemView.SingleSelection)
         self.tree.setDragDropMode(QAbstractItemView.InternalMove)
         self.tree.setDragEnabled(True)
@@ -139,6 +140,8 @@ class LayersWidget(QWidget):
         layout.addWidget(self.tree)
 
         self._apply_styles()
+
+        self._updating = False
 
         # Keep track of ongoing z-value animations to avoid repeatedly
         # re-triggering them when scene updates occur while an
@@ -162,14 +165,14 @@ class LayersWidget(QWidget):
         self.tree.setCurrentItem(titem)
 
     def _apply_styles(self):
-        """Applique un style plus moderne a la liste des calques."""
+        """Apply a darker style reminiscent of Blender's Outliner."""
         pal = self.tree.palette()
-        base = pal.base().color().name()
-        alt = pal.alternateBase().color().name()
-        text = pal.text().color().name()
+        base = "#2b2b2b"
+        alt = "#313131"
+        text = "#f0f0f0"
         highlight = pal.highlight().color().name()
         highlight_text = pal.highlightedText().color().name()
-        header_bg = pal.window().color().name()
+        header_bg = "#2b2b2b"
         border = pal.mid().color().name()
 
         self.tree.setStyleSheet(
@@ -205,8 +208,10 @@ class LayersWidget(QWidget):
             items = canvas.scene.selectedItems()
             selected = items[0] if items else None
 
+        self._updating = True
         self.tree.clear()
         if not canvas:
+            self._updating = False
             return
 
         project_name = getattr(canvas, "current_meta",
@@ -233,11 +238,17 @@ class LayersWidget(QWidget):
                 | Qt.ItemIsEditable
                 | Qt.ItemIsDragEnabled
                 | Qt.ItemIsDropEnabled
+                | Qt.ItemIsUserCheckable
             )
             qitem.setFlags(flags)
-            qitem.setText(1, "👁" if gitem.isVisible() else "🚫")
+            qitem.setCheckState(1, Qt.Checked if gitem.isVisible() else Qt.Unchecked)
             locked = not (gitem.flags() & QGraphicsItem.ItemIsMovable)
-            qitem.setText(2, "🔒" if locked else "🔓")
+            qitem.setCheckState(2, Qt.Unchecked if locked else Qt.Checked)
+            if isinstance(gitem, QGraphicsItemGroup):
+                icon = self.style().standardIcon(QStyle.SP_DirIcon)
+            else:
+                icon = self.style().standardIcon(QStyle.SP_FileIcon)
+            qitem.setIcon(0, icon)
             if isinstance(gitem, QGraphicsItemGroup):
                 qitem.setExpanded(True)
                 for child in sorted(gitem.childItems(), key=_sort_z):
@@ -253,6 +264,7 @@ class LayersWidget(QWidget):
         self._sync_scene_from_tree()
         if selected:
             self.highlight_item(selected)
+        self._updating = False
 
     # ------------------------------------------------------------------
     def highlight_item(self, item):
@@ -272,25 +284,22 @@ class LayersWidget(QWidget):
     # ------------------------------------------------------------------
     def _on_item_clicked(self, titem, column):
         self.tree.setCurrentItem(titem)
+
+    def _on_item_changed(self, titem, column):
+        if self._updating:
+            return
         gitem = titem.data(0, Qt.UserRole)
         if not gitem:
             return
-        if column == 1:
-            vis = not gitem.isVisible()
+        if column == 0:
+            gitem.layer_name = titem.text(0)
+        elif column == 1:
+            vis = titem.checkState(1) == Qt.Checked
             gitem.setVisible(vis)
-            titem.setText(1, "👁" if vis else "🚫")
         elif column == 2:
-            locked = not (gitem.flags() & QGraphicsItem.ItemIsMovable)
-            locked = not locked
+            locked = titem.checkState(2) != Qt.Checked
             gitem.setFlag(QGraphicsItem.ItemIsMovable, not locked)
             gitem.setFlag(QGraphicsItem.ItemIsSelectable, not locked)
-            titem.setText(2, "🔒" if locked else "🔓")
-
-    def _on_item_changed(self, titem, column):
-        if column == 0:
-            gitem = titem.data(0, Qt.UserRole)
-            if gitem:
-                gitem.layer_name = titem.text(0)
 
     def _on_selection_changed(self):
         if not self.canvas:


### PR DESCRIPTION
## Summary
- tweak layer dock style for a darker look
- use checkboxes and icons like Blender outliner
- track updates to avoid unwanted signal handling

## Testing
- `flake8`
- `python -m pictocode -h` *(fails: Qt platform plugin 'xcb' couldn't load)*

------
https://chatgpt.com/codex/tasks/task_e_685314d4a3c0832387a7c2049f76bbe2