### PR TITLE
Fix grouped layer mobility and add empty group creation

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1121,6 +1121,8 @@ class CanvasWidget(QGraphicsView):
         group.setFlags(
             QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
         )
+        # Allow interacting with children individually
+        group.setHandlesChildEvents(False)
         self._assign_layer_name(group, "group")
         self.scene.clearSelection()
         group.setSelected(True)
@@ -1144,6 +1146,7 @@ class CanvasWidget(QGraphicsView):
         group.setFlags(
             QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
         )
+        group.setHandlesChildEvents(False)
         self._assign_layer_name(group, name)
         self._schedule_scene_changed()
         return group

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -394,6 +394,9 @@ class LayersWidget(QWidget):
         act_dup = QAction("Dupliquer", menu)
         menu.addAction(act_dup)
         menu.addSeparator()
+        act_new_group = QAction("Nouvelle collection", menu)
+        menu.addAction(act_new_group)
+        menu.addSeparator()
         act_up = QAction("Monter", menu)
         menu.addAction(act_up)
         act_down = QAction("Descendre", menu)
@@ -416,6 +419,8 @@ class LayersWidget(QWidget):
             new_item = self.canvas.scene.selectedItems()[0]
             self.update_layers(self.canvas)
             self.highlight_item(new_item)
+        elif action is act_new_group:
+            insert_group(root.childCount())
         elif action is act_up:
             parent = item.parent() or self.tree.invisibleRootItem().child(0)
             idx = parent.indexOfChild(item)


### PR DESCRIPTION
## Summary
- allow interacting with items inside groups
- context menu option to create an empty collection anywhere

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853189590b08323a58fc3179037322a