### PR TITLE
Fix Qt5 compatibility for grouping

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1121,8 +1121,9 @@ class CanvasWidget(QGraphicsView):
         group.setFlags(
             QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
         )
-        # Allow interacting with children individually
-        group.setHandlesChildEvents(False)
+        # Allow interacting with children individually if supported (Qt >= 6)
+        if hasattr(group, "setHandlesChildEvents"):
+            group.setHandlesChildEvents(False)
         self._assign_layer_name(group, "group")
         self.scene.clearSelection()
         group.setSelected(True)
@@ -1146,7 +1147,8 @@ class CanvasWidget(QGraphicsView):
         group.setFlags(
             QGraphicsItem.ItemIsSelectable | QGraphicsItem.ItemIsMovable
         )
-        group.setHandlesChildEvents(False)
+        if hasattr(group, "setHandlesChildEvents"):
+            group.setHandlesChildEvents(False)
         self._assign_layer_name(group, name)
         self._schedule_scene_changed()
         return group


### PR DESCRIPTION
## Summary
- avoid calling `setHandlesChildEvents` on Qt5

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q pictocode && echo compile`


------
https://chatgpt.com/codex/tasks/task_e_68531bca38608323a1eb2acda3c07fba