### PR TITLE
Adjust layers panel interactions

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -132,10 +132,10 @@ class LayersWidget(QWidget):
         self.tree.setEditTriggers(
             QAbstractItemView.DoubleClicked
             | QAbstractItemView.EditKeyPressed
-            | QAbstractItemView.SelectedClicked
         )
         self.tree.setAlternatingRowColors(True)
         self.tree.header().setSectionResizeMode(QHeaderView.Stretch)
+        self.tree.header().hide()
         layout = QVBoxLayout(self)
         layout.addWidget(self.tree)
 
@@ -168,7 +168,7 @@ class LayersWidget(QWidget):
         """Apply a darker style reminiscent of Blender's Outliner."""
         pal = self.tree.palette()
         base = "#2b2b2b"
-        alt = "#313131"
+        alt = "#353535"
         text = "#f0f0f0"
         highlight = pal.highlight().color().name()
         highlight_text = pal.highlightedText().color().name()
@@ -185,6 +185,10 @@ class LayersWidget(QWidget):
             }}
             QTreeWidget::item {{
                 padding: 4px 2px;
+            }}
+            QTreeWidget::indicator {{
+                subcontrol-position: center right;
+                margin-right: 4px;
             }}
             QTreeWidget::item:selected {{
                 background: {highlight};


### PR DESCRIPTION
## Summary
- fix toggling by disabling edit on single click
- hide column headers in the layers panel
- right align item checkboxes and accentuate alternating rows

## Testing
- `pytest -q`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_68538c2cdfa08323a49d96f110990d67