### PR TITLE
Reduce lock column padding

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -193,7 +193,7 @@ class LayersWidget(QWidget):
                 border: 1px solid {border};
             }}
             QTreeWidget::item {{
-                padding: 4px 2px;
+                padding: 4px 1px 4px 0px;
             }}
             QTreeWidget::item:selected {{
                 background: {highlight};


### PR DESCRIPTION
## Summary
- tweak padding for tree view items so lock icon sits closer to the left edge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853934027988323810aed68ea1dfda4