### PR TITLE
Improve theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Une barre de titre personnalisée adopte également ces réglages, avec les bout
 de réduction, plein écran et fermeture.
 Les passages entre l'accueil et le canvas utilisent désormais un effet de fondu.
 
+Le panneau des calques suit maintenant automatiquement le thème choisi pour
+conserver un contraste optimal en mode clair comme en mode sombre.
+
 ### Raccourcis personnalisables
 
 Une boîte de dialogue **Préférences > Raccourcis…** permet de modifier les

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -183,14 +183,14 @@ class LayersWidget(QWidget):
         self.tree.setCurrentItem(titem)
 
     def _apply_styles(self):
-        """Apply a darker style reminiscent of Blender's Outliner."""
+        """Apply styles that follow the application palette."""
         pal = self.tree.palette()
-        base = "#2b2b2b"
-        alt = "#353535"
-        text = "#f0f0f0"
+        base = pal.base().color().name()
+        alt = pal.alternateBase().color().name()
+        text = pal.text().color().name()
         highlight = pal.highlight().color().name()
         highlight_text = pal.highlightedText().color().name()
-        header_bg = "#2b2b2b"
+        header_bg = pal.window().color().name()
         border = pal.mid().color().name()
 
         self.tree.setStyleSheet(


### PR DESCRIPTION
## Summary
- let layers panel style follow the active palette instead of using hardcoded dark colors
- document that the layers panel adapts to dark or light theme

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853cd51cb4c8323a79ddb64dfc4dbcd