### PR TITLE
Add mirroring feature

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -745,6 +745,22 @@ class CanvasWidget(QGraphicsView):
                 act_fill.triggered.connect(
                     lambda: self._change_brush_color(item))
                 menu.addAction(act_fill)
+            act_flip_h = QAction("Miroir horizontal", self)
+            act_flip_h.triggered.connect(
+                lambda: (
+                    item.setSelected(True),
+                    self.flip_horizontal_selected(),
+                )
+            )
+            menu.addAction(act_flip_h)
+            act_flip_v = QAction("Miroir vertical", self)
+            act_flip_v.triggered.connect(
+                lambda: (
+                    item.setSelected(True),
+                    self.flip_vertical_selected(),
+                )
+            )
+            menu.addAction(act_flip_v)
             act_delete = QAction("Supprimer", self)
             act_delete.triggered.connect(
                 lambda: (
@@ -1094,6 +1110,35 @@ class CanvasWidget(QGraphicsView):
 
     def zoom_out(self):
         self.scale(0.8, 0.8)
+
+    # --- Flip --------------------------------------------------------
+    def flip_horizontal_selected(self):
+        """Flip selected items horizontally around their center."""
+        items = [it for it in self.scene.selectedItems() if it is not self._frame_item]
+        if not items:
+            return
+        for it in items:
+            center = it.boundingRect().center()
+            orig = it.transformOriginPoint()
+            it.setTransformOriginPoint(center)
+            it.scale(-1, 1)
+            it.setTransformOriginPoint(orig)
+        self._mark_dirty()
+        self._schedule_scene_changed()
+
+    def flip_vertical_selected(self):
+        """Flip selected items vertically around their center."""
+        items = [it for it in self.scene.selectedItems() if it is not self._frame_item]
+        if not items:
+            return
+        for it in items:
+            center = it.boundingRect().center()
+            orig = it.transformOriginPoint()
+            it.setTransformOriginPoint(center)
+            it.scale(1, -1)
+            it.setTransformOriginPoint(orig)
+        self._mark_dirty()
+        self._schedule_scene_changed()
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Escape and self._temp_item:

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -155,6 +155,8 @@ class MainWindow(QMainWindow):
             "duplicate": "Ctrl+D",
             "delete": "Delete",
             "select_all": "Ctrl+A",
+            "flip_horizontal": "",
+            "flip_vertical": "",
             "zoom_in": "Ctrl++",
             "zoom_out": "Ctrl+-",
             "toggle_grid": "Ctrl+G",
@@ -261,6 +263,16 @@ class MainWindow(QMainWindow):
         dup_act.triggered.connect(self.duplicate_selection)
         editm.addAction(dup_act)
         self.actions["duplicate"] = dup_act
+
+        flip_h_act = QAction("Miroir horizontal", self)
+        flip_h_act.triggered.connect(self.flip_horizontal)
+        editm.addAction(flip_h_act)
+        self.actions["flip_horizontal"] = flip_h_act
+
+        flip_v_act = QAction("Miroir vertical", self)
+        flip_v_act.triggered.connect(self.flip_vertical)
+        editm.addAction(flip_v_act)
+        self.actions["flip_vertical"] = flip_v_act
 
         del_act = QAction("Supprimer", self)
         del_act.triggered.connect(self.delete_selection)
@@ -695,6 +707,12 @@ class MainWindow(QMainWindow):
 
     def duplicate_selection(self):
         self.canvas.duplicate_selected()
+
+    def flip_horizontal(self):
+        self.canvas.flip_horizontal_selected()
+
+    def flip_vertical(self):
+        self.canvas.flip_vertical_selected()
 
     def delete_selection(self):
         self.canvas.delete_selected()


### PR DESCRIPTION
## Summary
- add horizontal and vertical flip actions on the canvas
- expose flip actions through the Edit menu and context menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6853aecc3d4c8323b934ba66519d485d