### PR TITLE
Add Debian launcher script

### DIFF
--- a/pictocode.sh
+++ b/pictocode.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Script de lancement pour Pictocode sous Linux/Debian
+set -e
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR"
+
+if ! command -v pictocode >/dev/null 2>&1; then
+    echo "ERREUR : l'exécutable pictocode est introuvable."
+    echo "Installez-le d'abord avec 'pip install .' depuis ce dossier."
+    exit 1
+fi
+
+echo "[pictocode] Lancement de Pictocode…"
+pictocode "$@"
+status=$?
+if [ $status -ne 0 ]; then
+    echo "\nERREUR : échec du lancement de Pictocode."
+else
+    echo "\nPictocode s'est terminé normalement."
+fi


### PR DESCRIPTION
## Summary
- add a simple `pictocode.sh` launcher for Debian systems

## Testing
- `./pictocode.sh --help` *(fails: pictocode executable not found)*
- `pip install -e .`
- `./pictocode.sh -h` *(fails to start GUI due to missing Qt platform plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6853d1d8732883238159975bc299c0ad