### PR TITLE
Hide inspector without selection

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -847,8 +847,17 @@ class CanvasWidget(QGraphicsView):
                 window.inspector.set_target(items[0])
                 if hasattr(window, "layers"):
                     window.layers.highlight_item(items[0])
+                if hasattr(window, "inspector_dock"):
+                    window.inspector_dock.setVisible(True)
             else:
                 window.inspector.set_target(None)
+                if hasattr(window, "inspector_dock"):
+                    window.inspector_dock.setVisible(False)
+                if hasattr(window, "layers"):
+                    try:
+                        window.layers._clear_highlight()
+                    except AttributeError:
+                        pass
 
     def _mark_dirty(self):
         window = self.window()

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -470,7 +470,7 @@ class MainWindow(QMainWindow):
 
         # affiche toolbar et docks
         self.toolbar.setVisible(True)
-        self.inspector_dock.setVisible(True)
+        self.inspector_dock.setVisible(False)
         self.layers_dock.setVisible(True)
         self.imports_dock.setVisible(True)
         self._set_project_actions_enabled(True)
@@ -536,7 +536,7 @@ class MainWindow(QMainWindow):
         self.canvas.load_shapes(shapes or [])
         # bascule UI
         self.toolbar.setVisible(True)
-        self.inspector_dock.setVisible(True)
+        self.inspector_dock.setVisible(False)
         self.layers_dock.setVisible(True)
         self.imports_dock.setVisible(True)
         self._set_project_actions_enabled(True)


### PR DESCRIPTION
## Summary
- hide the inspector dock when no item is selected
- start projects with the inspector dock hidden

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853d6d9136c83239476db2956ccc1f5