### PR TITLE
Add inspector auto-show preference

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -843,15 +843,16 @@ class CanvasWidget(QGraphicsView):
         window = self.window()
         if hasattr(window, "inspector"):
             items = self.scene.selectedItems()
+            auto_show = getattr(window, "auto_show_inspector", True)
             if items:
                 window.inspector.set_target(items[0])
                 if hasattr(window, "layers"):
                     window.layers.highlight_item(items[0])
-                if hasattr(window, "inspector_dock"):
+                if auto_show and hasattr(window, "inspector_dock"):
                     window.inspector_dock.setVisible(True)
             else:
                 window.inspector.set_target(None)
-                if hasattr(window, "inspector_dock"):
+                if auto_show and hasattr(window, "inspector_dock"):
                     window.inspector_dock.setVisible(False)
                 if hasattr(window, "layers"):
                     try:

--- a/pictocode/ui/app_settings_dialog.py
+++ b/pictocode/ui/app_settings_dialog.py
@@ -35,6 +35,7 @@ class AppSettingsDialog(QDialog):
         rotation_handle_color: Optional[Union[QColor, str]] = None,
         autosave_enabled: bool = False,
         autosave_interval: int = 5,
+        auto_show_inspector: bool = True,
         parent=None,
     ):
 
@@ -148,6 +149,10 @@ class AppSettingsDialog(QDialog):
         self.autosave_spin.setValue(int(autosave_interval))
         form.addRow("Intervalle (min) :", self.autosave_spin)
 
+        self.auto_show_chk = QCheckBox()
+        self.auto_show_chk.setChecked(bool(auto_show_inspector))
+        form.addRow("Ouvrir inspecteur sur sélection :", self.auto_show_chk)
+
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
         )
@@ -210,3 +215,6 @@ class AppSettingsDialog(QDialog):
 
     def get_autosave_interval(self) -> int:
         return self.autosave_spin.value()
+
+    def get_auto_show_inspector(self) -> bool:
+        return self.auto_show_chk.isChecked()

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -78,6 +78,8 @@ class MainWindow(QMainWindow):
             "autosave_enabled", False, type=bool)
         self.autosave_interval = int(
             self.settings.value("autosave_interval", 5))
+        self.auto_show_inspector = self.settings.value(
+            "auto_show_inspector", True, type=bool)
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:
@@ -789,6 +791,7 @@ class MainWindow(QMainWindow):
             self.rotation_handle_color,
             self.autosave_enabled,
             self.autosave_interval,
+            self.auto_show_inspector,
             self,
         )
         if dlg.exec_() == QDialog.Accepted:
@@ -808,6 +811,7 @@ class MainWindow(QMainWindow):
             self.show_splash = dlg.get_show_splash()
             self.autosave_enabled = dlg.get_autosave_enabled()
             self.autosave_interval = dlg.get_autosave_interval()
+            self.auto_show_inspector = dlg.get_auto_show_inspector()
             self.apply_theme(
                 theme,
                 accent,
@@ -831,6 +835,7 @@ class MainWindow(QMainWindow):
             )
             self.settings.setValue("autosave_enabled", self.autosave_enabled)
             self.settings.setValue("autosave_interval", self.autosave_interval)
+            self.settings.setValue("auto_show_inspector", self.auto_show_inspector)
             if self.autosave_enabled:
                 self._autosave_timer.start(self.autosave_interval * 60000)
             else:


### PR DESCRIPTION
## Summary
- allow disabling automatic inspector visibility
- show "Open inspector on selection" setting in app preferences

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853d82b83188323b4c4ecede7c5608f