### PR TITLE
Fix immediate layer dragging

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
     QFrame,
     QStyle,
 )
-from PyQt5.QtCore import Qt, QPropertyAnimation
+from PyQt5.QtCore import Qt, QPropertyAnimation, QTimer
 from PyQt5.QtWidgets import QGraphicsObject
 from PyQt5.QtGui import QBrush, QColor
 from .animated_menu import AnimatedMenu
@@ -49,6 +49,19 @@ class LayersTreeWidget(QTreeWidget):
         self._drop_line.setStyleSheet(f"background:{self.drop_color.name()};")
         self._drop_line.hide()
         self._highlight_item = None
+
+    def mousePressEvent(self, event):
+        """Start a drag immediately when clicking on a layer."""
+        if event.button() == Qt.LeftButton:
+            col = self.columnAt(event.pos().x())
+            item = self.itemAt(event.pos())
+            super().mousePressEvent(event)
+            if item is not None and col == 0:
+                # Schedule the drag for the next event loop iteration so Qt
+                # has time to process the press normally first.
+                QTimer.singleShot(0, lambda: self.startDrag(Qt.MoveAction))
+            return
+        super().mousePressEvent(event)
 
     def _clear_highlight(self):
         if self._highlight_item:


### PR DESCRIPTION
## Summary
- schedule drag on next event cycle so layers move without extra mouse motion

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6853e26461a883238063b2d59e403630