### PR TITLE
Fix drag drop and selection

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -36,35 +36,12 @@ class TransparentItemGroup(QGraphicsItemGroup):
             self.setHandlesChildEvents(False)
 
 
-    def _ignore_if_unselected(self, event):
-        """Ignore the event when the group isn't selected."""
-        if not self.isSelected():
-            event.ignore()
-            return True
-        return False
-
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemSelectedHasChanged and hasattr(
             self, "setHandlesChildEvents"
         ):
             self.setHandlesChildEvents(bool(value))
         return super().itemChange(change, value)
-
-
-    def mousePressEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mousePressEvent(event)
-
-    def mouseMoveEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mouseMoveEvent(event)
-
-    def mouseReleaseEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mouseReleaseEvent(event)
 
 
     def _forward_or_handle(self, event, handler):

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -57,12 +57,11 @@ class LayersTreeWidget(QTreeWidget):
             item = self.itemAt(event.pos())
             super().mousePressEvent(event)
             if item is not None and col == 0:
-
                 # Schedule the drag for the next event loop iteration so Qt
-                # has time to process the press normally first.
+                # has time to process the press normally first. Starting the
+                # drag after the press event ensures the item becomes selected
+                # without requiring any mouse movement.
                 QTimer.singleShot(0, lambda: self.startDrag(Qt.MoveAction))
-                # Start the drag right away without requiring movement
-                self.startDrag(Qt.MoveAction)
             return
         super().mousePressEvent(event)
 


### PR DESCRIPTION
## Summary
- start layer drag after press so selection is processed
- clean up TransparentItemGroup to ensure children can be selected when parent is not

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547f8694e48323a1ade4520bf5980b