### PR TITLE
Fix drag drop and selection

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -26,61 +26,24 @@ from .utils import to_pixels
 
 
 class TransparentItemGroup(QGraphicsItemGroup):
-    """Item group that lets its children handle events unless selected."""
+    """Item group that handles events only when selected."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # ItemHasNoContents avoids painting the group while keeping a bounding rect
         self.setFlag(QGraphicsItem.ItemHasNoContents, True)
         if hasattr(self, "setHandlesChildEvents"):
+            # Let children receive events until the group becomes selected
             self.setHandlesChildEvents(False)
-
-
-    def _ignore_if_unselected(self, event):
-        """Ignore the event when the group isn't selected."""
-        if not self.isSelected():
-            event.ignore()
-            return True
-        return False
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemSelectedHasChanged and hasattr(
             self, "setHandlesChildEvents"
         ):
+            # Forward events to the children when not selected so they remain
+            # individually selectable.
             self.setHandlesChildEvents(bool(value))
         return super().itemChange(change, value)
-
-
-    def mousePressEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mousePressEvent(event)
-
-    def mouseMoveEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mouseMoveEvent(event)
-
-    def mouseReleaseEvent(self, event):
-        if self._ignore_if_unselected(event):
-            return
-        super().mouseReleaseEvent(event)
-
-
-    def _forward_or_handle(self, event, handler):
-        if self.isSelected():
-            handler(event)
-        else:
-            event.ignore()
-
-    def mousePressEvent(self, event):
-        self._forward_or_handle(event, super().mousePressEvent)
-
-    def mouseMoveEvent(self, event):
-        self._forward_or_handle(event, super().mouseMoveEvent)
-
-    def mouseReleaseEvent(self, event):
-        self._forward_or_handle(event, super().mouseReleaseEvent)
 
 
 

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -51,17 +51,14 @@ class LayersTreeWidget(QTreeWidget):
         self._highlight_item = None
 
     def mousePressEvent(self, event):
-        """Start a drag immediately when clicking on a layer."""
+        """Begin dragging as soon as a layer is pressed."""
         if event.button() == Qt.LeftButton:
             col = self.columnAt(event.pos().x())
             item = self.itemAt(event.pos())
             super().mousePressEvent(event)
             if item is not None and col == 0:
-
-                # Schedule the drag for the next event loop iteration so Qt
-                # has time to process the press normally first.
-                QTimer.singleShot(0, lambda: self.startDrag(Qt.MoveAction))
-                # Start the drag right away without requiring movement
+                # Qt has processed the press and updated selection, so start
+                # the drag right away without requiring any mouse movement.
                 self.startDrag(Qt.MoveAction)
             return
         super().mousePressEvent(event)


### PR DESCRIPTION
## Summary
- let child items handle events when group is not selected
- start layer drag immediately after clicking the name column

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68547f8694e48323a1ade4520bf5980b