### PR TITLE
Fix layers dock signal duplication and drag start

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -57,18 +57,10 @@ class LayersTreeWidget(QTreeWidget):
             item = self.itemAt(event.pos())
             super().mousePressEvent(event)
             if item is not None and col == 0:
-
-
-                # Qt has processed the press and updated selection, so start
-                # the drag right away without requiring any mouse movement.
-                self.startDrag(Qt.MoveAction)
-
-                # Schedule the drag for the next event loop iteration so Qt
-                # has time to process the press normally first. Starting the
-                # drag after the press event ensures the item becomes selected
-                # without requiring any mouse movement.
+                # Schedule the drag to start after Qt has processed the press
+                # event so the item becomes selected without requiring any
+                # mouse movement.
                 QTimer.singleShot(0, lambda: self.startDrag(Qt.MoveAction))
-
             return
         super().mousePressEvent(event)
 
@@ -191,10 +183,8 @@ class LayersWidget(QWidget):
         # animation is already running.
         self._z_anims = {}
 
-    def apply_theme(self):
-        """Re-apply styles when the application theme changes."""
-        self._apply_styles()
-
+        # Connect signals once during initialization. "apply_theme" will only
+        # re-apply styles without re-connecting to avoid duplicate callbacks.
         self.tree.itemPressed.connect(self._on_item_pressed)
         self.tree.itemClicked.connect(self._on_item_clicked)
         self.tree.itemChanged.connect(self._on_item_changed)
@@ -202,6 +192,10 @@ class LayersWidget(QWidget):
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
         self.tree.customContextMenuRequested.connect(self._open_menu)
         self.tree.viewport().setAcceptDrops(True)
+
+    def apply_theme(self):
+        """Re-apply styles when the application theme changes."""
+        self._apply_styles()
 
     def _on_item_pressed(self, titem, column):
         """Ensure the pressed item becomes current before dragging."""


### PR DESCRIPTION
## Summary
- avoid starting drag twice in `LayersTreeWidget.mousePressEvent`
- connect layers tree signals once in `LayersWidget.__init__`
- keep `apply_theme` for style updates only

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68550b2536808323aa7babab2e20d383