### PR TITLE
Fix missing QTimer import in layers dock

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
     QFrame,
     QStyle,
 )
-from PyQt5.QtCore import Qt, QPropertyAnimation
+from PyQt5.QtCore import Qt, QPropertyAnimation, QTimer
 from PyQt5.QtWidgets import QGraphicsObject
 from PyQt5.QtGui import QBrush, QColor, QTransform, QDrag
 from .animated_menu import AnimatedMenu


### PR DESCRIPTION
## Summary
- fix crash by importing QTimer in LayersDock

## Testing
- `python -m pictocode` *(fails: Qt platform plugin "xcb" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f0d593208323b495662e8bf552b9