### PR TITLE
Improve drag preview

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -109,7 +109,11 @@ class LayersTreeWidget(QTreeWidget):
         rect = self.visualItemRect(item)
         pixmap = self.viewport().grab(rect)
         transform = QTransform()
+        cx = pixmap.width() / 2
+        cy = pixmap.height() / 2
+        transform.translate(cx, cy)
         transform.rotate(8)
+        transform.translate(-cx, -cy)
         pixmap = pixmap.transformed(transform, Qt.SmoothTransformation)
         painter = QPainter(pixmap)
         painter.setCompositionMode(QPainter.CompositionMode_DestinationIn)

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -13,9 +13,9 @@ from PyQt5.QtWidgets import (
     QFrame,
     QStyle,
 )
-from PyQt5.QtCore import Qt, QPropertyAnimation
+from PyQt5.QtCore import Qt, QPropertyAnimation, QTimer
 from PyQt5.QtWidgets import QGraphicsObject
-from PyQt5.QtGui import QBrush, QColor, QTransform, QDrag
+from PyQt5.QtGui import QBrush, QColor, QTransform, QDrag, QPainter
 from .animated_menu import AnimatedMenu
 
 
@@ -60,9 +60,9 @@ class LayersTreeWidget(QTreeWidget):
             item = self.itemAt(event.pos())
             super().mousePressEvent(event)
             if item is not None and col == 0:
-                # Schedule a drag immediately so the row can be moved
-                # even if the mouse doesn't travel far after the press.
-                self.startDrag(Qt.MoveAction)
+                # Schedule a drag once the press event has been handled so the
+                # row can be moved smoothly even if the mouse doesn't travel
+                # far after the initial click.
                 QTimer.singleShot(0, lambda: self.startDrag(Qt.MoveAction))
             return
         super().mousePressEvent(event)
@@ -111,6 +111,10 @@ class LayersTreeWidget(QTreeWidget):
         transform = QTransform()
         transform.rotate(8)
         pixmap = pixmap.transformed(transform, Qt.SmoothTransformation)
+        painter = QPainter(pixmap)
+        painter.setCompositionMode(QPainter.CompositionMode_DestinationIn)
+        painter.fillRect(pixmap.rect(), QColor(0, 0, 0, 180))
+        painter.end()
         drag = QDrag(self)
         drag.setMimeData(self.mimeData(self.selectedItems()))
         drag.setPixmap(pixmap)


### PR DESCRIPTION
## Summary
- tweak drag start logic for smoother dragging
- show a semi-transparent drag preview image

## Testing
- `python -m pictocode` *(fails: Qt platform plugin "xcb" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f0d593208323b495662e8bf552b9