### PR TITLE
Fix QTreeWidgetItem hashing bug in LayersTreeWidget

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -58,13 +58,13 @@ class LayersTreeWidget(QTreeWidget):
         # pointer so Qt's default implementation doesn't attempt to serialize it,
         # which would otherwise produce ``QVariant::save`` warnings and break drag
         # animations on some platforms.
-        backup = {}
+        backup = []
         for it in items:
-            backup[it] = it.data(0, Qt.UserRole)
+            backup.append((it, it.data(0, Qt.UserRole)))
             it.setData(0, Qt.UserRole, None)
         mime = super().mimeData(items)
-        for it in items:
-            it.setData(0, Qt.UserRole, backup[it])
+        for it, data in backup:
+            it.setData(0, Qt.UserRole, data)
         return mime
 
     def mousePressEvent(self, event):


### PR DESCRIPTION
## Summary
- handle Qt item backup as a list in `LayersTreeWidget.mimeData`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685737fb3e2883239c1186b9d86dcb51