### PR TITLE
Add optional grouping on drag

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
     QFrame,
     QStyle,
 )
-from PyQt5.QtCore import Qt, QPropertyAnimation, QTimeLine, QTimer
+from PyQt5.QtCore import Qt, QPropertyAnimation, QTimeLine, QTimer, QVariantAnimation
 from PyQt5.QtWidgets import QGraphicsObject
 from PyQt5.QtGui import QBrush, QColor, QTransform, QDrag, QPainter
 from .animated_menu import AnimatedMenu
@@ -48,9 +48,68 @@ class LayersTreeWidget(QTreeWidget):
         self._drop_line.setStyleSheet(f"background:{self.drop_color.name()};")
         self._drop_line.setAttribute(Qt.WA_TransparentForMouseEvents)
         self._drop_line.hide()
+        self._drop_anim = None
         # Use a custom drop indicator to avoid flicker with Qt's built-in one
         self.setDropIndicatorShown(False)
         self._highlight_item = None
+        self._highlight_anim = None
+
+    # ------------------------------------------------------------------
+    def _fade_widget(self, widget, *, show=True, duration=150):
+        """Fade ``widget`` in or out with an opacity animation."""
+        if self._drop_anim:
+            self._drop_anim.stop()
+        widget.setWindowOpacity(0.0 if show else 1.0)
+        if show:
+            widget.show()
+        anim = QPropertyAnimation(widget, b"windowOpacity", self)
+        anim.setDuration(duration)
+        anim.setStartValue(0.0 if show else 1.0)
+        anim.setEndValue(1.0 if show else 0.0)
+
+        def _cleanup():
+            if not show:
+                widget.hide()
+            self._drop_anim = None
+
+        anim.finished.connect(_cleanup)
+        self._drop_anim = anim
+        anim.start(QPropertyAnimation.DeleteWhenStopped)
+
+    def _animate_highlight(self, item, *, start_color=None, end_color=None, duration=150):
+        """Animate ``item`` background color between ``start_color`` and ``end_color``."""
+        if not item:
+            return
+        if self._highlight_anim:
+            self._highlight_anim.stop()
+        if start_color is None:
+            start_color = self.group_color
+        if end_color is None:
+            end_color = QColor(0, 0, 0, 0)
+        anim = QVariantAnimation(self)
+        anim.setDuration(duration)
+        anim.setStartValue(start_color)
+        anim.setEndValue(end_color)
+
+        def _update(value):
+            try:
+                if item.treeWidget() is None:
+                    return
+                brush = QBrush(value)
+                for c in range(self.columnCount()):
+                    item.setBackground(c, brush)
+            except RuntimeError:
+                # The item was removed from the tree while the animation was
+                # running. Silently abort the update to avoid a crash.
+                return
+
+        def _cleanup():
+            self._highlight_anim = None
+
+        anim.valueChanged.connect(_update)
+        anim.finished.connect(_cleanup)
+        self._highlight_anim = anim
+        anim.start()
 
     def mimeData(self, items):
         """Return MIME data for ``items`` without serializing ``QGraphicsItem`` pointers."""
@@ -106,19 +165,10 @@ class LayersTreeWidget(QTreeWidget):
 
     def _clear_highlight(self):
         if self._highlight_item:
-            # The QTreeWidgetItem may have been removed from the tree during
-            # a drop operation. When this happens Qt deletes the underlying C++
-            # object and calling methods on it raises a RuntimeError. Guard by
-            # checking that the item still belongs to a tree before clearing
-            # its background colors. The call to ``treeWidget`` itself can
-            # raise ``RuntimeError`` if the wrapped C++ object has been
-            # deleted, so we also protect against that case.
             try:
                 if self._highlight_item.treeWidget() is not None:
-                    for c in range(self.columnCount()):
-                        self._highlight_item.setBackground(c, QBrush())
+                    self._animate_highlight(self._highlight_item)
             except RuntimeError:
-                # The underlying item was deleted; nothing to clear.
                 pass
         self._highlight_item = None
 
@@ -159,31 +209,43 @@ class LayersTreeWidget(QTreeWidget):
         event.setDropAction(Qt.MoveAction)
         super().dragMoveEvent(event)
         event.accept()
+
         item = self.itemAt(event.pos())
         pos = self.dropIndicatorPosition()
 
-        if (
-            pos in (QAbstractItemView.AboveItem, QAbstractItemView.BelowItem)
-            and item
-        ):
-            rect = self.visualItemRect(item)
-            y = (
-                rect.top()
-                if pos == QAbstractItemView.AboveItem
-                else rect.bottom()
-            )
-            self._drop_line.setGeometry(0, y, self.viewport().width(), 2)
-            self._drop_line.show()
-        else:
-            self._drop_line.hide()
+        line_y = None
+        highlight = False
 
-        if pos == QAbstractItemView.OnItem and item:
+        if pos in (QAbstractItemView.AboveItem, QAbstractItemView.BelowItem) and item:
+            rect = self.visualItemRect(item)
+            line_y = rect.top() if pos == QAbstractItemView.AboveItem else rect.bottom()
+        elif pos == QAbstractItemView.OnItem and item:
+            if event.keyboardModifiers() & Qt.ControlModifier:
+                highlight = True
+            else:
+                rect = self.visualItemRect(item)
+                center = rect.center().y()
+                line_y = rect.bottom() if event.pos().y() >= center else rect.top()
+        elif pos == QAbstractItemView.OnViewport:
+            last = self.itemAt(self.viewport().rect().bottomLeft())
+            if last:
+                rect = self.visualItemRect(last)
+                line_y = rect.bottom()
+            else:
+                line_y = self.viewport().rect().top()
+
+        if line_y is not None:
+            self._drop_line.setGeometry(0, line_y, self.viewport().width(), 2)
+            self._fade_widget(self._drop_line, show=True)
+        else:
+            if self._drop_line.isVisible():
+                self._fade_widget(self._drop_line, show=False)
+
+        if highlight:
             if self._highlight_item is not item:
                 self._clear_highlight()
                 self._highlight_item = item
-                brush = QBrush(self.group_color)
-                for c in range(self.columnCount()):
-                    item.setBackground(c, brush)
+                self._animate_highlight(item, start_color=self.group_color, end_color=self.group_color)
         elif item is not self._highlight_item:
             self._clear_highlight()
 
@@ -196,7 +258,8 @@ class LayersTreeWidget(QTreeWidget):
         self._handle_tree_drop(event)
 
     def _handle_tree_drop(self, event):
-        self._drop_line.hide()
+        if self._drop_line.isVisible():
+            self._fade_widget(self._drop_line, show=False)
         self._clear_highlight()
         super().dropEvent(event)
         if self._parent and hasattr(self._parent, "_handle_tree_drop"):
@@ -204,7 +267,8 @@ class LayersTreeWidget(QTreeWidget):
 
     def dragLeaveEvent(self, event):
         """Remove any drop indicators when the drag leaves the widget."""
-        self._drop_line.hide()
+        if self._drop_line.isVisible():
+            self._fade_widget(self._drop_line, show=False)
         self._clear_highlight()
         super().dragLeaveEvent(event)
 
@@ -614,14 +678,11 @@ class LayersWidget(QWidget):
             and selected
             and target_item not in self.tree.selectedItems()
             and self.canvas
+            and (event.keyboardModifiers() & Qt.ControlModifier)
         ):
             target_gitem = target_item.data(0, Qt.UserRole)
-            if target_gitem and not isinstance(
-                target_gitem, QGraphicsItemGroup
-            ):
-                items = [target_gitem] + sorted(
-                    selected, key=lambda g: g.zValue()
-                )
+            if target_gitem and not isinstance(target_gitem, QGraphicsItemGroup):
+                items = [target_gitem] + sorted(selected, key=lambda g: g.zValue())
                 group = self.canvas.group_selected(items, sort_items=False)
                 if group:
                     event.accept()


### PR DESCRIPTION
## Summary
- show a drop preview even when dropping at the end of the list
- require Ctrl when dropping on a layer to group items
- compute drop line position for viewport drops
- fade highlight animations when dropping
- fix drag move event modifier check

## Testing
- `python -m compileall -q pictocode/ui/layers_dock.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857f808828883239a21d108f000475e