### PR TITLE
Keep canvas interactive when switching layers

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -8,7 +8,6 @@ from PyQt5.QtWidgets import (
     QAction,
     QGraphicsItem,
     QGraphicsItemGroup,
-    QGraphicsObject,
 )
 from .ui.animated_menu import AnimatedMenu
 from PyQt5.QtCore import Qt, QRectF, QPointF, QSizeF, pyqtSignal, QTimer
@@ -281,7 +280,8 @@ class CanvasWidget(QGraphicsView):
         for s in shapes:
             self._create_item(s)
         self.scene.blockSignals(False)
-        window = self.window()
+        # Ensure layer and layout views stay in sync with the scene
+        self._schedule_scene_changed()
 
     def export_project(self):
         """
@@ -1125,6 +1125,10 @@ class CanvasWidget(QGraphicsView):
         for it in self.scene.items():
             if it is not self._frame_item:
                 it.setSelected(True)
+
+    def deselect_all(self):
+        """Clear selection on the scene."""
+        self.scene.clearSelection()
 
     def zoom_in(self):
         self.scale(1.25, 1.25)

--- a/pictocode/ui/layout_dock.py
+++ b/pictocode/ui/layout_dock.py
@@ -45,4 +45,12 @@ class LayoutWidget(QWidget):
         if not current:
             return
         name = current.data(0, Qt.UserRole)
-        self.main.canvas.select_item_by_name(name)
+        # Top-level items correspond to layers. Selecting them should only
+        # change the active layer, not select the underlying group which
+        # would block interaction with its children on the canvas.
+        if current.parent() is None:
+            # Avoid locking the canvas by leaving the layer group selected
+            self.main.canvas.deselect_all()
+            self.main.canvas.set_current_layer(name)
+        else:
+            self.main.canvas.select_item_by_name(name)


### PR DESCRIPTION
## Summary
- refresh layout after loading shapes
- provide a method to clear canvas selection
- avoid layer groups remaining selected in the layout tree

## Testing
- `python -m pyflakes pictocode`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_68580f8789808323af81c054502d4e88