### PR TITLE
Keep canvas interactive when switching layers

### DIFF
--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -1,39 +1,89 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QComboBox,
+    QToolButton,
+    QHBoxLayout,
+)
 from PyQt5.QtCore import Qt
 
 
 class LayersWidget(QWidget):
-    """Simple layer manager listing layers with visibility toggles."""
+    """Layer manager with selection bar and lock/visibility toggles."""
 
     def __init__(self, main_window, parent=None):
         super().__init__(parent)
         self.main = main_window
-        self.list = QListWidget()
-        self.list.itemChanged.connect(self._on_item_changed)
-        self.list.currentTextChanged.connect(self._on_current_changed)
+
+        self.combo = QComboBox(self)
+        self.combo.currentTextChanged.connect(self._on_combo_changed)
+        add_btn = QToolButton(self)
+        add_btn.setText("+")
+        add_btn.clicked.connect(self._add_layer)
+        del_btn = QToolButton(self)
+        del_btn.setText("-")
+        del_btn.clicked.connect(self._remove_layer)
+        bar = QHBoxLayout()
+        bar.setContentsMargins(0, 0, 0, 0)
+        bar.addWidget(self.combo)
+        bar.addWidget(add_btn)
+        bar.addWidget(del_btn)
+
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Calque", "Délock", "Visible"])
+        self.tree.itemChanged.connect(self._on_item_changed)
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.list)
+        layout.addLayout(bar)
+        layout.addWidget(self.tree)
 
     def populate(self):
-        """Refresh list from canvas layers."""
-        self.list.blockSignals(True)
-        self.list.clear()
+        """Refresh combo and list from canvas layers."""
+        self.combo.blockSignals(True)
+        self.tree.blockSignals(True)
+        self.combo.clear()
+        self.tree.clear()
         canvas = self.main.canvas
         for name in canvas.layer_names():
             layer = canvas.layers[name]
-            item = QListWidgetItem(name)
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-            item.setCheckState(Qt.Checked if layer.isVisible() else Qt.Unchecked)
-            self.list.addItem(item)
+            self.combo.addItem(name)
+            node = QTreeWidgetItem([name, "", ""])
+            node.setData(0, Qt.UserRole, name)
+            node.setFlags(node.flags() | Qt.ItemIsUserCheckable)
+            node.setCheckState(1, Qt.Checked if not getattr(layer, "locked", False) else Qt.Unchecked)
+            node.setCheckState(2, Qt.Checked if layer.isVisible() else Qt.Unchecked)
+            self.tree.addTopLevelItem(node)
             if canvas.current_layer and canvas.current_layer.layer_name == name:
-                self.list.setCurrentItem(item)
-        self.list.blockSignals(False)
+                self.combo.setCurrentText(name)
+                self.tree.setCurrentItem(node)
+        self.combo.blockSignals(False)
+        self.tree.blockSignals(False)
 
-    def _on_item_changed(self, item):
-        visible = item.checkState() == Qt.Checked
-        self.main.canvas.set_layer_visible(item.text(), visible)
+    def _on_item_changed(self, item, column):
+        name = item.data(0, Qt.UserRole)
+        if column == 1:
+            locked = item.checkState(1) != Qt.Checked
+            self.main.canvas.set_layer_locked(name, locked)
+        elif column == 2:
+            visible = item.checkState(2) == Qt.Checked
+            self.main.canvas.set_layer_visible(name, visible)
 
-    def _on_current_changed(self, name: str):
+    def _on_combo_changed(self, name: str):
         if name:
             self.main.canvas.set_current_layer(name)
+            self.populate()
+
+    def _add_layer(self):
+        canvas = self.main.canvas
+        base = f"Layer {len(canvas.layers) + 1}"
+        canvas.create_layer(base)
+        self.populate()
+
+    def _remove_layer(self):
+        name = self.combo.currentText()
+        if name:
+            self.main.canvas.remove_layer(name)
+            self.populate()

--- a/pictocode/ui/layout_dock.py
+++ b/pictocode/ui/layout_dock.py
@@ -45,4 +45,12 @@ class LayoutWidget(QWidget):
         if not current:
             return
         name = current.data(0, Qt.UserRole)
-        self.main.canvas.select_item_by_name(name)
+        # Top-level items correspond to layers. Selecting them should only
+        # change the active layer, not select the underlying group which
+        # would block interaction with its children on the canvas.
+        if current.parent() is None:
+            # Avoid locking the canvas by leaving the layer group selected
+            self.main.canvas.deselect_all()
+            self.main.canvas.set_current_layer(name)
+        else:
+            self.main.canvas.select_item_by_name(name)


### PR DESCRIPTION
## Summary
- refresh layout after loading shapes
- provide a method to clear canvas selection
- avoid layer groups remaining selected in the layout tree
- allow locking layers and pick active layer from a compact selector

## Testing
- `python -m pyflakes pictocode`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_68580f8789808323af81c054502d4e88