### PR TITLE
Refactor layers UI and add layer management helpers

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -8,7 +8,6 @@ from PyQt5.QtWidgets import (
     QAction,
     QGraphicsItem,
     QGraphicsItemGroup,
-    QGraphicsObject,
 )
 from .ui.animated_menu import AnimatedMenu
 from PyQt5.QtCore import Qt, QRectF, QPointF, QSizeF, pyqtSignal, QTimer
@@ -281,7 +280,8 @@ class CanvasWidget(QGraphicsView):
         for s in shapes:
             self._create_item(s)
         self.scene.blockSignals(False)
-        window = self.window()
+        # Ensure layer and layout views stay in sync with the scene
+        self._schedule_scene_changed()
 
     def export_project(self):
         """
@@ -297,7 +297,11 @@ class CanvasWidget(QGraphicsView):
                 shapes.append(data)
         meta = getattr(self, "current_meta", {})
         layers = [
-            {"name": name, "visible": layer.isVisible()}
+            {
+                "name": name,
+                "visible": layer.isVisible(),
+                "locked": getattr(layer, "locked", False),
+            }
             for name, layer in self.layers.items()
         ]
         return {**meta, "shapes": shapes, "layers": layers}
@@ -1126,6 +1130,10 @@ class CanvasWidget(QGraphicsView):
             if it is not self._frame_item:
                 it.setSelected(True)
 
+    def deselect_all(self):
+        """Clear selection on the scene."""
+        self.scene.clearSelection()
+
     def zoom_in(self):
         self.scale(1.25, 1.25)
 
@@ -1304,6 +1312,8 @@ class CanvasWidget(QGraphicsView):
         self._assign_layer_name(group, name)
         group.setVisible(visible)
         group.visible = visible
+        group.locked = False
+        group.setEnabled(True)
         self.layers[group.layer_name] = group
         if self.current_layer is None:
             self.current_layer = group
@@ -1313,6 +1323,11 @@ class CanvasWidget(QGraphicsView):
     def set_current_layer(self, name: str):
         if name in self.layers:
             self.current_layer = self.layers[name]
+            for n, layer in self.layers.items():
+                locked = n != name
+                layer.locked = locked
+                layer.setEnabled(not locked)
+            self._schedule_scene_changed()
 
     def set_layer_visible(self, name: str, visible: bool):
         layer = self.layers.get(name)
@@ -1321,8 +1336,92 @@ class CanvasWidget(QGraphicsView):
             layer.visible = visible
             self._schedule_scene_changed()
 
+    def set_layer_locked(self, name: str, locked: bool):
+        layer = self.layers.get(name)
+        if layer:
+            layer.locked = locked
+            layer.setEnabled(not locked)
+            self._schedule_scene_changed()
+
     def layer_names(self):
         return list(self.layers.keys())
+
+    def remove_layer(self, name: str):
+        if name not in self.layers or len(self.layers) <= 1:
+            return
+        layer = self.layers.pop(name)
+        self.scene.removeItem(layer)
+        if self.current_layer is layer:
+            self.current_layer = next(iter(self.layers.values()))
+        self.set_current_layer(self.current_layer.layer_name)
+        self._schedule_scene_changed()
+
+    def rename_layer(self, old: str, new: str):
+        if old not in self.layers or not new:
+            return
+        if new in self.layers:
+            base = new
+            i = 1
+            while f"{base} {i}" in self.layers:
+                i += 1
+            new = f"{base} {i}"
+        keys = list(self.layers.keys())
+        idx = keys.index(old)
+        layer = self.layers.pop(old)
+        layer.layer_name = new
+        for child in layer.childItems():
+            child.layer = new
+        keys[idx] = new
+        self.layers = OrderedDict((k, self.layers.get(k, layer) if k == new else self.layers[k]) for k in keys)
+        if self.current_layer is layer:
+            self.current_layer = layer
+        self._schedule_scene_changed()
+
+    def duplicate_layer(self, name: str):
+        if name not in self.layers:
+            return
+        src = self.layers[name]
+        base = f"{name} copy"
+        i = 1
+        new_name = base
+        while new_name in self.layers:
+            i += 1
+            new_name = f"{base} {i}"
+        new_layer = self.create_layer(new_name, src.isVisible())
+        idx = list(self.layers.keys()).index(name)
+        order = list(self.layers.keys())
+        order.remove(new_name)
+        order.insert(idx + 1, new_name)
+        self._reorder(order)
+        for item in src.childItems():
+            data = self._serialize_item(item)
+            if not data:
+                continue
+            for key in ("x", "x1", "x2"):
+                if key in data:
+                    data[key] += 10
+            for key in ("y", "y1", "y2"):
+                if key in data:
+                    data[key] += 10
+            data["layer"] = new_name
+            self._create_item(data)
+        self._schedule_scene_changed()
+
+    def move_layer(self, name: str, offset: int):
+        keys = list(self.layers.keys())
+        if name not in keys:
+            return
+        idx = keys.index(name)
+        new_idx = max(0, min(len(keys) - 1, idx + offset))
+        if new_idx == idx:
+            return
+        keys.insert(new_idx, keys.pop(idx))
+        self._reorder(keys)
+
+    def _reorder(self, names):
+        self.layers = OrderedDict((n, self.layers[n]) for n in names)
+        for z, n in enumerate(names):
+            self.layers[n].setZValue(z)
 
     def setup_layers(self, layers_data):
         """Configure les calques depuis une liste de dicts."""
@@ -1336,7 +1435,10 @@ class CanvasWidget(QGraphicsView):
         for layer in layers_data:
             name = layer.get("name") or f"Layer {len(self.layers)+1}"
             vis = layer.get("visible", True)
-            self.create_layer(name, vis)
+            grp = self.create_layer(name, vis)
+            if layer.get("locked"):
+                grp.locked = True
+                grp.setEnabled(False)
         first = layers_data[0]
         self.set_current_layer(first.get("name", self.layer_names()[0]))
 

--- a/pictocode/ui/layers_dock.py
+++ b/pictocode/ui/layers_dock.py
@@ -1,39 +1,143 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QToolButton,
+    QMenu,
+    QWidgetAction,
+)
+from PyQt5.QtCore import Qt, QPoint
 
 
 class LayersWidget(QWidget):
-    """Simple layer manager listing layers with visibility toggles."""
+    """Compact drop-down layer manager."""
 
     def __init__(self, main_window, parent=None):
         super().__init__(parent)
         self.main = main_window
-        self.list = QListWidget()
-        self.list.itemChanged.connect(self._on_item_changed)
-        self.list.currentTextChanged.connect(self._on_current_changed)
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.list)
 
+        self.button = QToolButton(self)
+        self.button.setPopupMode(QToolButton.InstantPopup)
+        self.button.clicked.connect(self._update_menu_text)
+
+        self.menu = QMenu(self)
+        self.menu.aboutToShow.connect(self.populate)
+        action = QWidgetAction(self.menu)
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Calque", "Lock", "Vis.", ""])
+        self.tree.itemChanged.connect(self._on_item_changed)
+        self.tree.itemClicked.connect(self._on_item_clicked)
+        self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.tree.customContextMenuRequested.connect(self._on_context_menu)
+        action.setDefaultWidget(self.tree)
+        self.menu.addAction(action)
+        self.button.setMenu(self.menu)
+
+        add_btn = QToolButton(self)
+        add_btn.setText("+")
+        add_btn.clicked.connect(self._add_layer)
+        del_btn = QToolButton(self)
+        del_btn.setText("-")
+        del_btn.clicked.connect(self._remove_layer)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.button)
+        layout.addWidget(add_btn)
+        layout.addWidget(del_btn)
+
+    # ------------------------------------------------------------------
     def populate(self):
-        """Refresh list from canvas layers."""
-        self.list.blockSignals(True)
-        self.list.clear()
+        """Refresh drop-down list from canvas layers."""
+        self.tree.blockSignals(True)
+        self.tree.clear()
         canvas = self.main.canvas
         for name in canvas.layer_names():
             layer = canvas.layers[name]
-            item = QListWidgetItem(name)
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-            item.setCheckState(Qt.Checked if layer.isVisible() else Qt.Unchecked)
-            self.list.addItem(item)
+            node = QTreeWidgetItem([name, "", "", ""])
+            node.setData(0, Qt.UserRole, name)
+            node.setFlags(
+                node.flags()
+                | Qt.ItemIsUserCheckable
+                | Qt.ItemIsEditable
+                | Qt.ItemIsSelectable
+            )
+            node.setCheckState(1, Qt.Checked if not getattr(layer, "locked", False) else Qt.Unchecked)
+            node.setCheckState(2, Qt.Checked if layer.isVisible() else Qt.Unchecked)
+            btn = QToolButton()
+            btn.setText("-")
+            btn.clicked.connect(lambda _, n=name: self._remove_layer_by_name(n))
+            self.tree.addTopLevelItem(node)
+            self.tree.setItemWidget(node, 3, btn)
             if canvas.current_layer and canvas.current_layer.layer_name == name:
-                self.list.setCurrentItem(item)
-        self.list.blockSignals(False)
+                self.tree.setCurrentItem(node)
+                self.button.setText(name)
+        self.tree.blockSignals(False)
 
-    def _on_item_changed(self, item):
-        visible = item.checkState() == Qt.Checked
-        self.main.canvas.set_layer_visible(item.text(), visible)
-
-    def _on_current_changed(self, name: str):
+    # ------------------------------------------------------------------
+    def _on_item_clicked(self, item, column):
+        name = item.data(0, Qt.UserRole)
         if name:
             self.main.canvas.set_current_layer(name)
+            self.button.setText(name)
+            self.menu.hide()
+
+    def _on_item_changed(self, item, column):
+        name = item.data(0, Qt.UserRole)
+        if column == 0:
+            new_name = item.text(0)
+            if new_name and new_name != name:
+                self.main.canvas.rename_layer(name, new_name)
+                item.setData(0, Qt.UserRole, new_name)
+                self.button.setText(new_name)
+        elif column == 1:
+            locked = item.checkState(1) != Qt.Checked
+            self.main.canvas.set_layer_locked(name, locked)
+        elif column == 2:
+            visible = item.checkState(2) == Qt.Checked
+            self.main.canvas.set_layer_visible(name, visible)
+
+    def _update_menu_text(self):
+        layer = self.main.canvas.current_layer
+        if layer:
+            self.button.setText(layer.layer_name)
+
+    # ------------------------------------------------------------------
+    def _add_layer(self):
+        base = f"Layer {len(self.main.canvas.layers) + 1}"
+        self.main.canvas.create_layer(base)
+        self.populate()
+
+    def _remove_layer(self):
+        item = self.tree.currentItem()
+        name = item.data(0, Qt.UserRole) if item else None
+        if name:
+            self.main.canvas.remove_layer(name)
+            self.populate()
+
+    def _remove_layer_by_name(self, name: str):
+        self.main.canvas.remove_layer(name)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def _on_context_menu(self, pos: QPoint):
+        item = self.tree.itemAt(pos)
+        if not item:
+            return
+        name = item.data(0, Qt.UserRole)
+        menu = QMenu(self)
+        dup = menu.addAction("Dupliquer")
+        up = menu.addAction("Monter")
+        down = menu.addAction("Descendre")
+        delete = menu.addAction("Supprimer")
+        act = menu.exec_(self.tree.mapToGlobal(pos))
+        if act == dup:
+            self.main.canvas.duplicate_layer(name)
+        elif act == up:
+            self.main.canvas.move_layer(name, -1)
+        elif act == down:
+            self.main.canvas.move_layer(name, 1)
+        elif act == delete:
+            self.main.canvas.remove_layer(name)
+        self.populate()

--- a/pictocode/ui/layout_dock.py
+++ b/pictocode/ui/layout_dock.py
@@ -45,4 +45,12 @@ class LayoutWidget(QWidget):
         if not current:
             return
         name = current.data(0, Qt.UserRole)
-        self.main.canvas.select_item_by_name(name)
+        # Top-level items correspond to layers. Selecting them should only
+        # change the active layer, not select the underlying group which
+        # would block interaction with its children on the canvas.
+        if current.parent() is None:
+            # Avoid locking the canvas by leaving the layer group selected
+            self.main.canvas.deselect_all()
+            self.main.canvas.set_current_layer(name)
+        else:
+            self.main.canvas.select_item_by_name(name)

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -123,12 +123,7 @@ class MainWindow(QMainWindow):
 
         # Calques
         self.layers = LayersWidget(self)
-        l_dock = QDockWidget("Calques", self)
-        l_dock.setWidget(self.layers)
-        l_dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
-        self.addDockWidget(Qt.LeftDockWidgetArea, l_dock)
-        l_dock.setVisible(False)
-        self.layers_dock = l_dock
+        self.toolbar.addWidget(self.layers)
 
 
         # Layout / outliner
@@ -411,13 +406,6 @@ class MainWindow(QMainWindow):
         viewm.addAction(imp_act)
         self.actions["view_imports"] = imp_act
 
-        layers_act = QAction("Calques", self, checkable=True)
-        layers_act.toggled.connect(self.layers_dock.setVisible)
-        self.layers_dock.visibilityChanged.connect(layers_act.setChecked)
-        viewm.addAction(layers_act)
-        self.actions["view_layers"] = layers_act
-
-
         layout_act = QAction("Plan", self, checkable=True)
         layout_act.toggled.connect(self.layout_dock.setVisible)
         self.layout_dock.visibilityChanged.connect(layout_act.setChecked)
@@ -501,7 +489,6 @@ class MainWindow(QMainWindow):
         self.toolbar.setVisible(True)
         self.inspector_dock.setVisible(False)
         self.imports_dock.setVisible(True)
-        self.layers_dock.setVisible(True)
         self.layout_dock.setVisible(True)
 
         self._set_project_actions_enabled(True)
@@ -575,7 +562,6 @@ class MainWindow(QMainWindow):
         self.toolbar.setVisible(True)
         self.inspector_dock.setVisible(False)
         self.imports_dock.setVisible(True)
-        self.layers_dock.setVisible(True)
         self.layout_dock.setVisible(True)
 
         self._set_project_actions_enabled(True)
@@ -1133,10 +1119,6 @@ class MainWindow(QMainWindow):
             act = self.actions.get("view_imports")
             if act:
                 act.setChecked(self.imports_dock.isVisible())
-            act = self.actions.get("view_layers")
-            if act:
-                act.setChecked(self.layers_dock.isVisible())
-
             act = self.actions.get("view_layout")
             if act:
                 act.setChecked(self.layout_dock.isVisible())


### PR DESCRIPTION
## Summary
- make layers dropdown show all controls in a popup list
- integrate the layer selector directly in the toolbar
- support renaming, duplicating, moving and deleting layers in `CanvasWidget`

## Testing
- `python -m pyflakes pictocode`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_68580f8789808323af81c054502d4e88