### PR TITLE
Fix selection of items on canvas

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -35,6 +35,8 @@ class TransparentItemGroup(QGraphicsItemGroup):
         if hasattr(self, "setHandlesChildEvents"):
             # Let children receive events until the group becomes selected
             self.setHandlesChildEvents(False)
+        # Ignore mouse events when not selected so child items stay clickable
+        self.setAcceptedMouseButtons(Qt.NoButton)
 
 
     def itemChange(self, change, value):
@@ -44,16 +46,22 @@ class TransparentItemGroup(QGraphicsItemGroup):
             # Forward events to the children when not selected so they remain
             # individually selectable.
             self.setHandlesChildEvents(bool(value))
+            self.setAcceptedMouseButtons(
+                Qt.AllButtons if value else Qt.NoButton
+            )
         return super().itemChange(change, value)
 
-    def _forward_or_handle(self, event, handler):
+    def shape(self):
+        """Make the group transparent to clicks when not selected."""
         if self.isSelected():
-            handler(event)
-        else:
-            event.ignore()
+            return super().shape()
+        return QPainterPath()
 
     def mousePressEvent(self, event):
-        self._forward_or_handle(event, super().mousePressEvent)
+        if self.isSelected():
+            super().mousePressEvent(event)
+        else:
+            event.ignore()
 
 
 

--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -303,6 +303,7 @@ class Rect(ResizableMixin, SnapToGridMixin, QGraphicsRectItem):
         self.setAcceptHoverEvents(True)
         self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
+        self.setTransformOriginPoint(w / 2, h / 2)
 
     def rect(self):
         return QGraphicsRectItem.rect(self)
@@ -333,6 +334,7 @@ class Ellipse(ResizableMixin, SnapToGridMixin, QGraphicsEllipseItem):
         self.setAcceptHoverEvents(True)
         self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
+        self.setTransformOriginPoint(w / 2, h / 2)
 
     def rect(self):
         return QGraphicsEllipseItem.rect(self)
@@ -430,6 +432,8 @@ class Line(LineResizableMixin, SnapToGridMixin, QGraphicsLineItem):
         self.setAcceptHoverEvents(True)
         self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
+        br = self.boundingRect()
+        self.setTransformOriginPoint(br.center())
 
 
 class FreehandPath(ResizableMixin, SnapToGridMixin, QGraphicsPathItem):
@@ -459,6 +463,8 @@ class FreehandPath(ResizableMixin, SnapToGridMixin, QGraphicsPathItem):
         self.setAcceptHoverEvents(True)
         self.var_name = ""
         self.setToolTip("Clique droit pour modifier")
+        br = self.boundingRect()
+        self.setTransformOriginPoint(br.width() / 2, br.height() / 2)
 
     def rect(self):
         return self.path().boundingRect()
@@ -520,6 +526,8 @@ class TextItem(ResizableMixin, SnapToGridMixin, QGraphicsTextItem):
         self.var_name = ""
         self.alignment = "left"
         self.setToolTip("Clique droit pour modifier")
+        br = self.boundingRect()
+        self.setTransformOriginPoint(br.width() / 2, br.height() / 2)
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemPositionChange and self.scene():
@@ -559,6 +567,7 @@ class ImageItem(ResizableMixin, SnapToGridMixin, QGraphicsPixmapItem):
             | QGraphicsPixmapItem.ItemSendsGeometryChanges
         )
         self.setAcceptHoverEvents(True)
+        self.setTransformOriginPoint(pix.width() / 2, pix.height() / 2)
         self.var_name = ""
 
     def rect(self):


### PR DESCRIPTION
## Summary
- make TransparentItemGroup ignore mouse hits unless selected
- update transform origins for shapes so rotation centers stay correct

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68582f1c51848323a9726db087350d43