### PR TITLE
Fix syntax errors for pictocode launch

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -308,8 +308,8 @@ class CanvasWidget(QGraphicsView):
         Prêt à sérialiser en JSON.
         """
         shapes = []
-        for item in reversed(self.scene.items()):
         logger.debug("Exporting project")
+        for item in reversed(self.scene.items()):
             if item is self._frame_item:
                 continue
             data = self._serialize_item(item)

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -1,7 +1,8 @@
 # pictocode/ui/main_window.py
-import os, json
-from PyQt5.QtWidgets import (
+import os
+import json
 import logging
+from PyQt5.QtWidgets import (
     QMainWindow,
     QDockWidget,
     QStackedWidget,


### PR DESCRIPTION
## Summary
- fix erroneous placement of `logging` import in `MainWindow`
- correct indentation in `export_project` to remove an `IndentationError`

## Testing
- `python -m compileall pictocode`
- `python -m pictocode` *(fails: Qt platform plugin "xcb" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858522945d4832395d4e196c3ec1e2f