### PR TITLE
Add logging for shape movements

### DIFF
--- a/pictocode/shapes.py
+++ b/pictocode/shapes.py
@@ -20,6 +20,9 @@ from PyQt5.QtGui import (
 )
 import math
 from PyQt5.QtCore import Qt, QPointF, QRectF
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class SnapToGridMixin:
@@ -33,6 +36,15 @@ class SnapToGridMixin:
                 grid = view.grid_size / scale
                 value.setX(round(value.x() / grid) * grid)
                 value.setY(round(value.y() / grid) * grid)
+            logger.debug(
+                f"{getattr(self, 'layer_name', type(self).__name__)} moving to "
+                f"{value.x():.1f},{value.y():.1f}"
+            )
+        elif change == QGraphicsItem.ItemPositionHasChanged:
+            logger.debug(
+                f"{getattr(self, 'layer_name', type(self).__name__)} position "
+                f"changed to {value.x():.1f},{value.y():.1f}"
+            )
         return super().itemChange(change, value)
 
 
@@ -537,6 +549,15 @@ class TextItem(ResizableMixin, SnapToGridMixin, QGraphicsTextItem):
                 grid = view.grid_size / scale
                 value.setX(round(value.x() / grid) * grid)
                 value.setY(round(value.y() / grid) * grid)
+            logger.debug(
+                f"{getattr(self, 'layer_name', type(self).__name__)} moving to "
+                f"{value.x():.1f},{value.y():.1f}"
+            )
+        elif change == QGraphicsItem.ItemPositionHasChanged:
+            logger.debug(
+                f"{getattr(self, 'layer_name', type(self).__name__)} position "
+                f"changed to {value.x():.1f},{value.y():.1f}"
+            )
         return super().itemChange(change, value)
 
     def rect(self):


### PR DESCRIPTION
## Summary
- add logger to shapes.py
- log position changes for shapes and text items

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68585d6c41108323a39cf30624d803d9