### PR TITLE
Fix TransparentItemGroup hit testing

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -78,10 +78,8 @@ class TransparentItemGroup(QGraphicsItemGroup):
         return super().itemChange(change, value)
 
     def shape(self):
-        """Make the group transparent to clicks when not selected."""
-        if self.isSelected():
-            return super().shape()
-        return QPainterPath()
+        """Return the combined shape of children for hit tests."""
+        return super().shape()
 
     def mousePressEvent(self, event):
         if self.isSelected():


### PR DESCRIPTION
## Summary
- ensure TransparentItemGroup provides a valid shape

## Testing
- `python -m py_compile pictocode/canvas.py pictocode/shapes.py`
- `python -m py_compile pictocode/*.py pictocode/ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685905a88128832382dd0684b547f77a