### PR TITLE
Fix inspector field update handling

### DIFF
--- a/pictocode/core.py
+++ b/pictocode/core.py
@@ -23,9 +23,9 @@ class CanvasModel:
         rect = Rect(x, y, w, h, color=color)
         self.shapes.append(rect)
         return rect
-        logger.debug(f"Add ellipse at ({x},{y}) size {w}x{h}")
 
     def add_ellipse(self, x, y, w, h, color: QColor = QColor("black")):
+        logger.debug(f"Add ellipse at ({x},{y}) size {w}x{h}")
         ellipse = Ellipse(x, y, w, h, color=color)
         self.shapes.append(ellipse)
         return ellipse

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
 )
+import logging
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QLinearGradient, QBrush, QColor
 from .gradient_editor import GradientEditorDialog
@@ -229,8 +230,10 @@ class Inspector(QWidget):
                 value = fld.text()
             setter(value)
             self._notify_change()
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).exception(
+                "Failed to update %s", fld, exc_info=exc
+            )
 
     def _pick_color(self, event=None):
         if not self._item:
@@ -365,4 +368,3 @@ class Inspector(QWidget):
                 view = views[0]
                 if hasattr(view, "_mark_dirty"):
                     view._mark_dirty()
-


### PR DESCRIPTION
## Summary
- log exceptions when updating inspector fields instead of silently ignoring them

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 pictocode/ui/inspector.py`


------
https://chatgpt.com/codex/tasks/task_e_68590a9fa61c8323a4326a2d12b61148