### PR TITLE
Add debug menu and report

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -750,6 +750,7 @@ class CanvasWidget(QGraphicsView):
                 if self.current_layer:
                     self.current_layer.addToGroup(self._current_path_item)
                     self._current_path_item.layer = self.current_layer.layer_name
+                self._current_path_item.setSelected(True)
             self._current_path_item = None
             self._freehand_points = None
             self._mark_dirty()
@@ -769,6 +770,7 @@ class CanvasWidget(QGraphicsView):
             if self.current_layer:
                 self.current_layer.addToGroup(self._temp_item)
                 self._temp_item.layer = self.current_layer.layer_name
+            self._temp_item.setSelected(True)
             self._temp_item = None
             self._mark_dirty()
             self._schedule_scene_changed()
@@ -809,6 +811,7 @@ class CanvasWidget(QGraphicsView):
             if self.current_layer:
                 self.current_layer.addToGroup(self._polygon_item)
                 self._polygon_item.layer = self.current_layer.layer_name
+            self._polygon_item.setSelected(True)
             self.scene.removeItem(self._poly_preview_line)
             self._poly_preview_line = None
             self._polygon_item = None
@@ -1617,4 +1620,37 @@ class CanvasWidget(QGraphicsView):
                 self.ensureVisible(it.sceneBoundingRect())
                 break
 
+
+
+    def get_debug_report(self) -> str:
+        """Return a textual report about the current project state."""
+        lines = []
+        meta = getattr(self, "current_meta", {})
+        lines.append("== Meta ==")
+        for k, v in meta.items():
+            lines.append(f"{k}: {v}")
+        lines.append("")
+        lines.append("== Layers ==")
+        for name, layer in self.layers.items():
+            locked = getattr(layer, "locked", False)
+            lines.append(
+                f"{name}: visible={layer.isVisible()} locked={locked} enabled={layer.isEnabled()}"
+            )
+        lines.append("")
+        lines.append(f"Current layer: {getattr(self.current_layer, 'layer_name', '')}")
+        lines.append(f"Lock others: {self.lock_others}")
+        lines.append("")
+        lines.append("== Selection ==")
+        selected = [
+            getattr(it, "layer_name", type(it).__name__)
+            for it in self.scene.selectedItems()
+        ]
+        lines.append(", ".join(selected) if selected else "(none)")
+        lines.append("")
+        lines.append(
+            f"History index: {self._history_index} / {len(self._history)}"
+        )
+        lines.append(f"Snap to grid: {self.snap_to_grid} size={self.grid_size}")
+        lines.append(f"Items in scene: {len(self.scene.items())}")
+        return "\n".join(lines)
 

--- a/pictocode/core.py
+++ b/pictocode/core.py
@@ -23,9 +23,9 @@ class CanvasModel:
         rect = Rect(x, y, w, h, color=color)
         self.shapes.append(rect)
         return rect
-        logger.debug(f"Add ellipse at ({x},{y}) size {w}x{h}")
 
     def add_ellipse(self, x, y, w, h, color: QColor = QColor("black")):
+        logger.debug(f"Add ellipse at ({x},{y}) size {w}x{h}")
         ellipse = Ellipse(x, y, w, h, color=color)
         self.shapes.append(ellipse)
         return ellipse

--- a/pictocode/ui/__init__.py
+++ b/pictocode/ui/__init__.py
@@ -9,6 +9,7 @@ from .layers_dock import LayersWidget
 
 from .layout_dock import LayoutWidget
 from .logs_dock import LogsWidget
+from .debug_dialog import DebugDialog
 
 
 
@@ -21,4 +22,5 @@ __all__ = [
     "LayersWidget",
     "LayoutWidget",
     "LogsWidget",
+    "DebugDialog",
 ]

--- a/pictocode/ui/debug_dialog.py
+++ b/pictocode/ui/debug_dialog.py
@@ -1,0 +1,32 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QPlainTextEdit,
+    QDialogButtonBox,
+    QApplication,
+)
+from PyQt5.QtCore import Qt
+
+
+class DebugDialog(QDialog):
+    """Simple dialog to display debug information with a copy button."""
+
+    def __init__(self, text: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Debug")
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+        self.text_edit = QPlainTextEdit(self)
+        self.text_edit.setReadOnly(True)
+        self.text_edit.setPlainText(text)
+        layout.addWidget(self.text_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Close, Qt.Horizontal, self)
+        copy_btn = buttons.addButton("Copier", QDialogButtonBox.ActionRole)
+        copy_btn.clicked.connect(self._copy)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _copy(self):
+        QApplication.clipboard().setText(self.text_edit.toPlainText())

--- a/pictocode/ui/inspector.py
+++ b/pictocode/ui/inspector.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
 )
+import logging
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QLinearGradient, QBrush, QColor
 from .gradient_editor import GradientEditorDialog
@@ -229,8 +230,10 @@ class Inspector(QWidget):
                 value = fld.text()
             setter(value)
             self._notify_change()
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).exception(
+                "Failed to update %s", fld, exc_info=exc
+            )
 
     def _pick_color(self, event=None):
         if not self._item:
@@ -365,4 +368,3 @@ class Inspector(QWidget):
                 view = views[0]
                 if hasattr(view, "_mark_dirty"):
                     view._mark_dirty()
-

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -33,6 +33,7 @@ from .layers_dock import LayersWidget
 from .layout_dock import LayoutWidget
 
 from .logs_dock import LogsWidget
+from .debug_dialog import DebugDialog
 
 logger = logging.getLogger(__name__)
 PROJECTS_DIR = os.path.join(os.path.dirname(
@@ -396,6 +397,11 @@ class MainWindow(QMainWindow):
         props_act.triggered.connect(self.open_project_settings)
         projectm.addAction(props_act)
         self.actions["project_props"] = props_act
+
+        debug_act = QAction("Debug", self)
+        debug_act.triggered.connect(self.show_debug_dialog)
+        projectm.addAction(debug_act)
+        self.actions["debug"] = debug_act
 
         viewm = AnimatedMenu("Affichage", self)
         mb.addMenu(viewm)
@@ -901,6 +907,14 @@ class MainWindow(QMainWindow):
                 if action is not None:
                     action.setShortcut(QKeySequence(seq))
                     self.settings.setValue(f"shortcut_{name}", seq)
+
+    def show_debug_dialog(self):
+        """Display a dialog with debug information about the project."""
+        if not hasattr(self, "canvas"):
+            return
+        text = self.canvas.get_debug_report()
+        dlg = DebugDialog(text, self)
+        dlg.exec_()
 
     def _switch_page(self, widget):
         current = self.stack.currentWidget()


### PR DESCRIPTION
## Summary
- add a `Debug` dialog to show project status and history info
- connect new dialog through a menu action under **Projet**
- expose `DebugDialog` from the UI package
- implement `CanvasWidget.get_debug_report`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 pictocode/ui/debug_dialog.py pictocode/ui/main_window.py pictocode/ui/__init__.py` *(fails: E303 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68590a9fa61c8323a4326a2d12b61148