### PR TITLE
Attach docks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ l'application.
 ### Gestion des fenetres
 
 Un panneau lateral "Panneaux" permet d'activer ou non diverses fenetres : proprietes, barre d'outils ou encore la liste des images importees.
+Par defaut, ces fenetres sont rattachees a la fenetre principale et ne flottent plus.
 La barre de titre personnalisée prend désormais en charge le déplacement système
 pour profiter des raccourcis de redimensionnement Windows (snap et agrandissement
 au bord de l'écran).

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -94,8 +94,9 @@ class MainWindow(QMainWindow):
             self.settings.value("autosave_interval", 5))
         self.auto_show_inspector = self.settings.value(
             "auto_show_inspector", True, type=bool)
+        # By default dock widgets are attached to the main window
         self.float_docks = self.settings.value(
-            "float_docks", True, type=bool)
+            "float_docks", False, type=bool)
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:


### PR DESCRIPTION
## Summary
- default to attached dock widgets instead of floating
- document the new behavior in README

## Testing
- `python -m compileall -q pictocode/ui/main_window.py`
- `python -m compileall -q main.py pictocode`

------
https://chatgpt.com/codex/tasks/task_e_685970ac4f508323820c302a6b5a8d29