### PR TITLE
Attach docks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ l'application.
 ### Gestion des fenetres
 
 Un panneau lateral "Panneaux" permet d'activer ou non diverses fenetres : proprietes, barre d'outils ou encore la liste des images importees.
+Par defaut, ces fenetres sont rattachees a la fenetre principale et ne flottent plus.
+Les panneaux peuvent être masqués ou affichés sans recentrer le plan de travail, la surface visible s'étend simplement.
 La barre de titre personnalisée prend désormais en charge le déplacement système
 pour profiter des raccourcis de redimensionnement Windows (snap et agrandissement
 au bord de l'écran).

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
 )
-from PyQt5.QtCore import Qt, QSettings, QPropertyAnimation, QTimer, QEvent
+from PyQt5.QtCore import Qt, QSettings, QPropertyAnimation, QTimer
 from PyQt5.QtGui import QPalette, QColor, QKeySequence
 from PyQt5.QtWidgets import QApplication
 from ..utils import generate_pycode, get_contrast_color
@@ -94,8 +94,9 @@ class MainWindow(QMainWindow):
             self.settings.value("autosave_interval", 5))
         self.auto_show_inspector = self.settings.value(
             "auto_show_inspector", True, type=bool)
+        # By default dock widgets are attached to the main window
         self.float_docks = self.settings.value(
-            "float_docks", True, type=bool)
+            "float_docks", False, type=bool)
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:
@@ -159,14 +160,6 @@ class MainWindow(QMainWindow):
         lg_dock.setFloating(self.float_docks)
         lg_dock.setVisible(False)
         self.logs_dock = lg_dock
-
-        for d in (
-            self.inspector_dock,
-            self.imports_dock,
-            self.layout_dock,
-            self.logs_dock,
-        ):
-            d.installEventFilter(self)
 
         self._apply_float_docks()
 
@@ -1148,16 +1141,8 @@ class MainWindow(QMainWindow):
                 dock.setFloating(False)
 
     def _toggle_dock(self, dock: QWidget, visible: bool):
-        """Show or hide a dock without shifting the canvas."""
-        center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
+        """Simply show or hide a dock widget."""
         dock.setVisible(visible)
-        QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
-
-    def eventFilter(self, obj, event):
-        if isinstance(obj, QDockWidget) and event.type() == QEvent.Close:
-            center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
-            QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
-        return super().eventFilter(obj, event)
 
     def _apply_handle_settings(self):
         from ..shapes import ResizableMixin


### PR DESCRIPTION
## Summary
- default to attached dock widgets instead of floating
- document the new behavior in README
- keep the canvas position fixed when panels are shown or hidden

## Testing
- `python -m compileall -q pictocode/ui/main_window.py`
- `python -m compileall -q main.py pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685970ac4f508323820c302a6b5a8d29