### PR TITLE
Fix canvas shift when hiding docks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ l'application.
 ### Gestion des fenetres
 
 Un panneau lateral "Panneaux" permet d'activer ou non diverses fenetres : proprietes, barre d'outils ou encore la liste des images importees.
+Par defaut, ces fenetres sont rattachees a la fenetre principale et ne flottent plus.
+Le plan de travail reste fixe : masquer ou afficher un panneau devoile simplement une plus grande partie de la zone visible sans la deplacer.
 La barre de titre personnalisée prend désormais en charge le déplacement système
 pour profiter des raccourcis de redimensionnement Windows (snap et agrandissement
 au bord de l'écran).

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
 )
-from PyQt5.QtCore import Qt, QSettings, QPropertyAnimation, QTimer, QEvent
+from PyQt5.QtCore import Qt, QSettings, QPropertyAnimation, QTimer, QEvent, QPointF
 from PyQt5.QtGui import QPalette, QColor, QKeySequence
 from PyQt5.QtWidgets import QApplication
 from ..utils import generate_pycode, get_contrast_color
@@ -94,8 +94,9 @@ class MainWindow(QMainWindow):
             self.settings.value("autosave_interval", 5))
         self.auto_show_inspector = self.settings.value(
             "auto_show_inspector", True, type=bool)
+        # By default dock widgets are attached to the main window
         self.float_docks = self.settings.value(
-            "float_docks", True, type=bool)
+            "float_docks", False, type=bool)
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:
@@ -1148,15 +1149,23 @@ class MainWindow(QMainWindow):
                 dock.setFloating(False)
 
     def _toggle_dock(self, dock: QWidget, visible: bool):
-        """Show or hide a dock without shifting the canvas."""
-        center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
+        """Show or hide a dock without shifting the viewport."""
+        top_left = self.canvas.mapToScene(0, 0)
         dock.setVisible(visible)
-        QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
+        def restore():
+            view = self.canvas.viewport().rect()
+            center = top_left + QPointF(view.width() / 2, view.height() / 2)
+            self.canvas.centerOn(center)
+        QTimer.singleShot(0, restore)
 
     def eventFilter(self, obj, event):
         if isinstance(obj, QDockWidget) and event.type() == QEvent.Close:
-            center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
-            QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
+            top_left = self.canvas.mapToScene(0, 0)
+            def restore():
+                view = self.canvas.viewport().rect()
+                center = top_left + QPointF(view.width() / 2, view.height() / 2)
+                self.canvas.centerOn(center)
+            QTimer.singleShot(0, restore)
         return super().eventFilter(obj, event)
 
     def _apply_handle_settings(self):


### PR DESCRIPTION
## Summary
- keep dock widgets attached by default
- maintain scroll position when showing or closing docks
- document that the workspace view no longer moves when panels are toggled
- preserve viewport position when docks are closed
- fix missing `QPointF` import

## Testing
- `python -m compileall -q pictocode/ui/main_window.py`
- `python -m compileall -q main.py pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685970ac4f508323820c302a6b5a8d29