### PR TITLE
Fix canvas shift when hiding docks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ l'application.
 ### Gestion des fenetres
 
 Un panneau lateral "Panneaux" permet d'activer ou non diverses fenetres : proprietes, barre d'outils ou encore la liste des images importees.
+Par defaut, ces fenetres sont rattachees a la fenetre principale et ne flottent plus.
+Le plan de travail reste fixe : masquer ou afficher un panneau devoile simplement une plus grande partie de la zone visible sans la deplacer, quel que soit le cote auquel il est rattache.
 La barre de titre personnalisée prend désormais en charge le déplacement système
 pour profiter des raccourcis de redimensionnement Windows (snap et agrandissement
 au bord de l'écran).

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QDialog,
     QGraphicsOpacityEffect,
+    QToolBar,
 )
 from PyQt5.QtCore import Qt, QSettings, QPropertyAnimation, QTimer, QEvent
 from PyQt5.QtGui import QPalette, QColor, QKeySequence
@@ -94,8 +95,9 @@ class MainWindow(QMainWindow):
             self.settings.value("autosave_interval", 5))
         self.auto_show_inspector = self.settings.value(
             "auto_show_inspector", True, type=bool)
+        # By default dock widgets are attached to the main window
         self.float_docks = self.settings.value(
-            "float_docks", True, type=bool)
+            "float_docks", False, type=bool)
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._autosave)
         if self.autosave_enabled:
@@ -1148,15 +1150,60 @@ class MainWindow(QMainWindow):
                 dock.setFloating(False)
 
     def _toggle_dock(self, dock: QWidget, visible: bool):
-        """Show or hide a dock without shifting the canvas."""
-        center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
+        """Show or hide a dock without shifting the viewport."""
+        view = self.canvas.viewport()
+        old_w = view.width()
+        old_h = view.height()
+        hbar = self.canvas.horizontalScrollBar()
+        vbar = self.canvas.verticalScrollBar()
+        old_hval = hbar.value()
+        old_vval = vbar.value()
+        if isinstance(dock, QDockWidget):
+            area = self.dockWidgetArea(dock)
+        elif isinstance(dock, QToolBar):
+            area = self.toolBarArea(dock)
+        else:
+            area = None
         dock.setVisible(visible)
-        QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
+
+        def restore():
+            dw = view.width() - old_w
+            dh = view.height() - old_h
+            h = old_hval
+            v = old_vval
+            if area in (Qt.LeftDockWidgetArea, Qt.LeftToolBarArea):
+                h -= dw
+            elif area in (Qt.TopDockWidgetArea, Qt.TopToolBarArea):
+                v -= dh
+            hbar.setValue(h)
+            vbar.setValue(v)
+
+        QTimer.singleShot(0, restore)
 
     def eventFilter(self, obj, event):
         if isinstance(obj, QDockWidget) and event.type() == QEvent.Close:
-            center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
-            QTimer.singleShot(0, lambda c=center: self.canvas.centerOn(c))
+            view = self.canvas.viewport()
+            old_w = view.width()
+            old_h = view.height()
+            hbar = self.canvas.horizontalScrollBar()
+            vbar = self.canvas.verticalScrollBar()
+            old_hval = hbar.value()
+            old_vval = vbar.value()
+            area = self.dockWidgetArea(obj)
+
+            def restore():
+                dw = view.width() - old_w
+                dh = view.height() - old_h
+                h = old_hval
+                v = old_vval
+                if area == Qt.LeftDockWidgetArea:
+                    h -= dw
+                elif area == Qt.TopDockWidgetArea:
+                    v -= dh
+                hbar.setValue(h)
+                vbar.setValue(v)
+
+            QTimer.singleShot(0, restore)
         return super().eventFilter(obj, event)
 
     def _apply_handle_settings(self):


### PR DESCRIPTION
## Summary
- keep workspace location when any panel is toggled
- update README about fixed viewport
- fix missing `QToolBar` import so `_toggle_dock` handles toolbars

## Testing
- `python -m compileall -q pictocode/ui/main_window.py`
- `python -m compileall -q main.py pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685970ac4f508323820c302a6b5a8d29