### PR TITLE
Ajout d'onglets glissables

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,0 +1,32 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QComboBox,
+    QStackedLayout,
+)
+from PyQt5.QtCore import Qt
+
+class CornerTabs(QWidget):
+    """Small tab widget that appears in the bottom-right corner."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("corner_tabs")
+        self.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.selector = QComboBox(self)
+        layout.addWidget(self.selector)
+        self.stack = QStackedLayout()
+        layout.addLayout(self.stack)
+        self.selector.currentIndexChanged.connect(
+            self.stack.setCurrentIndex
+        )
+        self.hide()
+
+    def add_tab(self, widget, label):
+        """Add a new tab with the given widget."""
+        self.selector.addItem(label)
+        self.stack.addWidget(widget)
+
+


### PR DESCRIPTION
## Summary
- remplace le widget d'onglets par un panneau avec menu déroulant
- activation du panneau en glissant depuis le coin de chaque dock
- déplacement automatique du panneau lors du redimensionnement

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile pictocode/ui/main_window.py pictocode/ui/corner_tabs.py`
- `python -m compileall -q`

------
https://chatgpt.com/codex/tasks/task_e_685980984c1083238c05bfcd952f7b1a