### PR TITLE
Hide dock tabs on home

### DIFF
--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -274,6 +274,12 @@ class MainWindow(QMainWindow):
         self._load_shortcuts()
         self._set_project_actions_enabled(False)
 
+        # hide docks while on the home page
+        self.inspector_dock.hide()
+        self.imports_dock.hide()
+        self.layout_dock.hide()
+        self.logs_dock.hide()
+
     def _create_dock(self, label, area):
         dock = QDockWidget(label, self)
 
@@ -541,6 +547,7 @@ class MainWindow(QMainWindow):
         self.inspector_dock.setVisible(False)
         self.imports_dock.setVisible(True)
         self.layout_dock.setVisible(True)
+        self.logs_dock.setVisible(True)
 
         self._set_project_actions_enabled(True)
         # bascule sur le canvas
@@ -615,6 +622,7 @@ class MainWindow(QMainWindow):
         self.inspector_dock.setVisible(False)
         self.imports_dock.setVisible(True)
         self.layout_dock.setVisible(True)
+        self.logs_dock.setVisible(True)
 
         self._set_project_actions_enabled(True)
         self._switch_page(self.canvas)
@@ -750,6 +758,8 @@ class MainWindow(QMainWindow):
         self.toolbar.setVisible(False)
         self.inspector_dock.setVisible(False)
         self.imports_dock.setVisible(False)
+        self.layout_dock.setVisible(False)
+        self.logs_dock.setVisible(False)
         self._set_project_actions_enabled(False)
 
     # --- Edit actions -------------------------------------------------


### PR DESCRIPTION
## Summary
- hide all dock widgets while on the home page
- display logs dock when opening or creating a project
- hide layout and logs docks when returning to the home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a62b318c08323ba634f10dfaeca9b