### PR TITLE
Preview dock split while dragging

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -142,6 +142,10 @@ class CanvasWidget(QGraphicsView):
         self.scene.itemAdded.connect(self._schedule_scene_changed)
         self.scene.itemRemoved.connect(self._schedule_scene_changed)
 
+        # Hide default scroll bars for a cleaner look
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
         # Timer to throttle layer updates when many changes occur
         self._scene_changed_timer = QTimer(self)
         self._scene_changed_timer.setSingleShot(True)

--- a/pictocode/ui/corner_handle.py
+++ b/pictocode/ui/corner_handle.py
@@ -1,0 +1,23 @@
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPainter, QPen
+
+
+class CornerHandle(QWidget):
+    """Small handle shown in the bottom right corner of dock widgets."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("corner_handle")
+        self.setFixedSize(12, 12)
+        self.setCursor(Qt.ArrowCursor)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        pen = QPen(self.palette().color(self.foregroundRole()), 1)
+        painter.setPen(pen)
+        for i in range(3):
+            offset = 3 + i * 3
+            painter.drawLine(0, self.height() - offset, self.width() - offset, self.height())
+        painter.end()

--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
 from PyQt5.QtCore import Qt, pyqtSignal
 
 class CornerTabs(QWidget):
@@ -21,6 +21,18 @@ class CornerTabs(QWidget):
         self.selector.currentTextChanged.connect(self._emit_change)
         if overlay:
             self.hide()
+
+    def contextMenuEvent(self, event):
+        """Show a menu allowing the dock to be closed."""
+        menu = QMenu(self)
+        remove = menu.addAction("Supprimer")
+        chosen = menu.exec_(event.globalPos())
+        if chosen == remove:
+            dock = self.parent()
+            if isinstance(dock, QDockWidget):
+                dock.close()
+        else:
+            super().contextMenuEvent(event)
 
     def add_tab(self, widget, label: str):
         """Compatibility shim for the previous API.

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
     QToolBar,
+    QHBoxLayout,
 )
 from PyQt5.QtCore import (
     Qt,
@@ -41,6 +42,7 @@ from .shortcut_settings_dialog import ShortcutSettingsDialog
 from .imports_dock import ImportsWidget
 from .layers_dock import LayersWidget
 from .layout_dock import LayoutWidget
+from .corner_handle import CornerHandle
 
 from .logs_dock import LogsWidget
 from .debug_dialog import DebugDialog
@@ -94,6 +96,7 @@ class MainWindow(QMainWindow):
         self._corner_start = QPointF()
         self._corner_current_dock = None
         self._split_orientation = Qt.Horizontal
+        self._split_preview_dock = None
 
         # Paramètres de l'application
         self.settings = QSettings("pictocode", "pictocode")
@@ -296,6 +299,13 @@ class MainWindow(QMainWindow):
         lay.setContentsMargins(0, 0, 0, 0)
         widget = self.category_widgets[label]
         lay.addWidget(widget)
+        handle_layout = QHBoxLayout()
+        handle_layout.setContentsMargins(0, 0, 2, 2)
+        handle_layout.addStretch()
+        handle = CornerHandle(container)
+        handle_layout.addWidget(handle)
+        handle.installEventFilter(self)
+        lay.addLayout(handle_layout)
         container.setLayout(lay)
         dock.setWidget(container)
         if self.float_docks:
@@ -1104,6 +1114,9 @@ class MainWindow(QMainWindow):
                 background: red;
                 border: 1px solid {accent.darker(150).name()};
             }}
+            QWidget#corner_handle {{
+                background: transparent;
+            }}
             """
         )
         self.inspector_dock.setStyleSheet(
@@ -1212,25 +1225,27 @@ class MainWindow(QMainWindow):
             elif event.type() == QEvent.MouseMove and self._corner_dragging and dock is self._corner_dragging_dock:
                 delta = event.globalPos() - self._corner_start
                 self._update_drag_indicator(event.globalPos())
-                if abs(delta.x()) > 5 or abs(delta.y()) > 5:
-                    if abs(delta.y()) >= abs(delta.x()):
-                        self._split_orientation = Qt.Vertical
-                    else:
-                        self._split_orientation = Qt.Horizontal
-                    self._split_current_dock(dock, delta)
-                    self._hide_drag_indicator()
-
-                    self._corner_dragging = False
-                    self._corner_dragging_dock = None
+                if not self._split_preview_dock:
+                    if abs(delta.x()) > 5 or abs(delta.y()) > 5:
+                        if abs(delta.y()) >= abs(delta.x()):
+                            self._split_orientation = Qt.Vertical
+                        else:
+                            self._split_orientation = Qt.Horizontal
+                        self._split_preview_dock = self._start_split_preview(dock)
+                if self._split_preview_dock:
+                    self._update_split_preview(dock, delta)
                 return True
             elif event.type() == QEvent.MouseButtonRelease and self._corner_dragging and dock is self._corner_dragging_dock:
                 delta = event.globalPos() - self._corner_start
-                if abs(delta.x()) > 5 or abs(delta.y()) > 5:
+                if self._split_preview_dock:
+                    self._update_split_preview(dock, delta)
+                    self._split_preview_dock.setWindowOpacity(1.0)
+                    self._split_preview_dock = None
+                elif abs(delta.x()) > 5 or abs(delta.y()) > 5:
                     if abs(delta.y()) >= abs(delta.x()):
                         self._split_orientation = Qt.Vertical
                     else:
                         self._split_orientation = Qt.Horizontal
-
                     self._split_current_dock(dock, delta)
                 self._corner_dragging = False
                 self._corner_dragging_dock = None
@@ -1285,6 +1300,42 @@ class MainWindow(QMainWindow):
     def _hide_drag_indicator(self):
         self.drag_indicator.hide()
 
+    def _start_split_preview(self, dock):
+        label = dock.windowTitle()
+        header = self.dock_headers.get(dock)
+        if header:
+            label = header.selector.currentText()
+        area = self.dockWidgetArea(dock)
+        new_dock = self._create_dock(label, area)
+        new_dock.setWindowOpacity(0.85)
+        new_dock.setMinimumSize(1, 1)
+        try:
+            self.splitDockWidget(dock, new_dock, self._split_orientation)
+            if self._split_orientation == Qt.Horizontal:
+                self.resizeDocks(
+                    [dock, new_dock], [dock.width(), 0], Qt.Horizontal
+                )
+            else:
+                self.resizeDocks(
+                    [dock, new_dock], [dock.height(), 0], Qt.Vertical
+                )
+        except Exception:
+            pass
+        return new_dock
+
+    def _update_split_preview(self, dock, delta):
+        new_dock = self._split_preview_dock
+        if not new_dock:
+            return
+        if self._split_orientation == Qt.Horizontal:
+            w1 = max(1, dock.width() - abs(delta.x()))
+            w2 = max(1, abs(delta.x()))
+            self.resizeDocks([dock, new_dock], [w1, w2], Qt.Horizontal)
+        else:
+            h1 = max(1, dock.height() - abs(delta.y()))
+            h2 = max(1, abs(delta.y()))
+            self.resizeDocks([dock, new_dock], [h1, h2], Qt.Vertical)
+
 
     def _split_current_dock(self, dock, delta):
         """Create a new dock based on the drag delta."""
@@ -1300,12 +1351,12 @@ class MainWindow(QMainWindow):
             pass
         # resize according to drag distance
         if self._split_orientation == Qt.Horizontal:
-            w1 = max(50, dock.width() - abs(delta.x()))
-            w2 = max(50, abs(delta.x()))
+            w1 = max(1, dock.width() - abs(delta.x()))
+            w2 = max(1, abs(delta.x()))
             self.resizeDocks([dock, new_dock], [w1, w2], Qt.Horizontal)
         else:
-            h1 = max(50, dock.height() - abs(delta.y()))
-            h2 = max(50, abs(delta.y()))
+            h1 = max(1, dock.height() - abs(delta.y()))
+            h2 = max(1, abs(delta.y()))
             self.resizeDocks([dock, new_dock], [h1, h2], Qt.Vertical)
 
     def set_dock_category(self, dock, label):


### PR DESCRIPTION
## Summary
- hide default scroll bars on the canvas view
- add visible corner handle widget in each dock
- preview new dock size while dragging from the handle
- enable closing a dock via a context menu on its tab bar
- allow preview dock to resize smoothly while dragging
- install event filter on the handle so dragging it works

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685a65b05f888323842df21bf5fd1d48