### PR TITLE
Allow live resizing when splitting docks

### DIFF
--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -96,7 +96,8 @@ class MainWindow(QMainWindow):
         self._corner_start = QPointF()
         self._corner_current_dock = None
         self._split_orientation = Qt.Horizontal
-        self._split_preview = None
+        self._split_preview = None  # legacy, unused
+        self._split_start_size = None
 
         # Paramètres de l'application
         self.settings = QSettings("pictocode", "pictocode")
@@ -1117,10 +1118,6 @@ class MainWindow(QMainWindow):
             QWidget#corner_handle {{
                 background: transparent;
             }}
-            QWidget#split_preview {{
-                border: 1px dashed {accent.darker(150).name()};
-                background: transparent;
-            }}
             """
         )
         self.inspector_dock.setStyleSheet(
@@ -1228,25 +1225,23 @@ class MainWindow(QMainWindow):
                     return True
             elif event.type() == QEvent.MouseMove and self._corner_dragging and dock is self._corner_dragging_dock:
                 delta = event.globalPos() - self._corner_start
-                self._update_drag_indicator(event.globalPos())
-                if not self._split_preview:
+                if self._corner_current_dock is None:
+                    self._update_drag_indicator(event.globalPos())
                     if abs(delta.x()) > 5 or abs(delta.y()) > 5:
                         if abs(delta.y()) >= abs(delta.x()):
                             self._split_orientation = Qt.Vertical
                         else:
                             self._split_orientation = Qt.Horizontal
-                        self._split_preview = self._start_split_preview(dock)
-                if self._split_preview:
-                    self._update_split_preview(dock, delta)
+                        self._begin_live_split(dock, delta)
+                        self._hide_drag_indicator()
+                else:
+                    self._update_live_split(dock, delta)
                 return True
             elif event.type() == QEvent.MouseButtonRelease and self._corner_dragging and dock is self._corner_dragging_dock:
                 delta = event.globalPos() - self._corner_start
-                if self._split_preview:
-                    self._update_split_preview(dock, delta)
-                    self._split_preview.hide()
-                    self._split_preview.deleteLater()
-                    self._split_preview = None
-                    self._split_current_dock(dock, delta)
+                if self._corner_current_dock is not None:
+                    self._update_live_split(dock, delta)
+                    self._corner_current_dock = None
                 elif abs(delta.x()) > 5 or abs(delta.y()) > 5:
                     if abs(delta.y()) >= abs(delta.x()):
                         self._split_orientation = Qt.Vertical
@@ -1306,39 +1301,90 @@ class MainWindow(QMainWindow):
     def _hide_drag_indicator(self):
         self.drag_indicator.hide()
 
-    def _start_split_preview(self, dock):
-        """Create a floating widget to preview the future dock."""
-        preview = QWidget(self)
-        preview.setObjectName("split_preview")
-        preview.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint)
-        preview.setAttribute(Qt.WA_TransparentForMouseEvents)
+    def show_corner_tabs(self):
+        """Display a floating tab selector near the cursor."""
+        if not self.corner_tabs:
+            self.corner_tabs = CornerTabs(self, overlay=True)
+        pos = self.mapFromGlobal(QCursor.pos())
+        self.corner_tabs.move(pos.x(), pos.y())
+        self.corner_tabs.show()
+        self.corner_tabs.raise_()
 
-        br = dock.mapTo(self, dock.rect().bottomRight())
-        preview.setGeometry(br.x(), br.y(), 1, 1)
-        preview.show()
-
-        preview.raise_()
-        return preview
-
-    def _update_split_preview(self, dock, delta):
-        preview = self._split_preview
-        if not preview:
-            return
-        br = dock.mapTo(self, dock.rect().bottomRight())
-        x = br.x()
-        y = br.y()
-        w = max(1, abs(delta.x()))
-        h = max(1, abs(delta.y()))
-        if delta.x() < 0:
-            x -= w
-        if delta.y() < 0:
-            y -= h
-        preview.setGeometry(x, y, w, h)
-
-        if abs(delta.y()) >= abs(delta.x()):
-            self._split_orientation = Qt.Vertical
+    def _animate_new_dock(self, dock, orientation):
+        """Animate ``dock`` growing along ``orientation``."""
+        dock.show()
+        if orientation == Qt.Horizontal:
+            end_value = dock.width()
+            dock.setMaximumWidth(1)
+            anim_prop = b"maximumWidth"
         else:
-            self._split_orientation = Qt.Horizontal
+            end_value = dock.height()
+            dock.setMaximumHeight(1)
+            anim_prop = b"maximumHeight"
+        anim = QPropertyAnimation(dock, anim_prop, self)
+        anim.setDuration(150)
+        anim.setStartValue(1)
+        anim.setEndValue(end_value)
+        dock._anim = anim
+
+        def _cleanup():
+            if orientation == Qt.Horizontal:
+                dock.setMaximumWidth(end_value)
+            else:
+                dock.setMaximumHeight(end_value)
+            if hasattr(dock, "_anim"):
+                delattr(dock, "_anim")
+
+        anim.finished.connect(_cleanup)
+        anim.start()
+
+    def _begin_live_split(self, dock, delta):
+        """Create the new dock when the user starts dragging."""
+        label = dock.windowTitle()
+        header = self.dock_headers.get(dock)
+        if header:
+            label = header.selector.currentText()
+        area = self.dockWidgetArea(dock)
+        new_dock = self._create_dock(label, area)
+        self._split_start_size = (dock.width(), dock.height())
+        try:
+            if self._split_orientation == Qt.Horizontal:
+                if delta.x() >= 0:
+                    self.splitDockWidget(dock, new_dock, Qt.Horizontal)
+                    self.resizeDocks([dock, new_dock], [dock.width() - 1, 1], Qt.Horizontal)
+                else:
+                    self.splitDockWidget(new_dock, dock, Qt.Horizontal)
+                    self.resizeDocks([new_dock, dock], [1, dock.width() - 1], Qt.Horizontal)
+            else:
+                if delta.y() >= 0:
+                    self.splitDockWidget(dock, new_dock, Qt.Vertical)
+                    self.resizeDocks([dock, new_dock], [dock.height() - 1, 1], Qt.Vertical)
+                else:
+                    self.splitDockWidget(new_dock, dock, Qt.Vertical)
+                    self.resizeDocks([new_dock, dock], [1, dock.height() - 1], Qt.Vertical)
+        except Exception:
+            pass
+        self._corner_current_dock = new_dock
+
+    def _update_live_split(self, dock, delta):
+        """Resize docks while the user drags."""
+        new = self._corner_current_dock
+        if not new or self._split_start_size is None:
+            return
+        if self._split_orientation == Qt.Horizontal:
+            w2 = max(1, abs(delta.x()))
+            w1 = max(1, self._split_start_size[0] - w2)
+            if delta.x() >= 0:
+                self.resizeDocks([dock, new], [w1, w2], Qt.Horizontal)
+            else:
+                self.resizeDocks([new, dock], [w2, w1], Qt.Horizontal)
+        else:
+            h2 = max(1, abs(delta.y()))
+            h1 = max(1, self._split_start_size[1] - h2)
+            if delta.y() >= 0:
+                self.resizeDocks([dock, new], [h1, h2], Qt.Vertical)
+            else:
+                self.resizeDocks([new, dock], [h2, h1], Qt.Vertical)
 
 
     def _split_current_dock(self, dock, delta):
@@ -1349,6 +1395,7 @@ class MainWindow(QMainWindow):
             label = header.selector.currentText()
         area = self.dockWidgetArea(dock)
         new_dock = self._create_dock(label, area)
+        new_dock.hide()
         try:
             if self._split_orientation == Qt.Horizontal:
                 if delta.x() >= 0:
@@ -1374,6 +1421,7 @@ class MainWindow(QMainWindow):
                     self.resizeDocks([new_dock, dock], [h1, h2], Qt.Vertical)
         except Exception:
             pass
+        self._animate_new_dock(new_dock, self._split_orientation)
 
     def set_dock_category(self, dock, label):
         widget = self.category_widgets.get(label)


### PR DESCRIPTION
## Summary
- create new dock as soon as the drag exceeds the threshold
- resize the original and new docks live while dragging
- keep a short animation for quick splits and store animations per dock
- remove unused preview widget styling

## Testing
- `python -m py_compile pictocode/ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_685bbc214bf08323b48425fe3df6eabd