### PR TITLE
Fix compatibility with PyQt5 by replacing frameWidth usage

### DIFF
--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -61,10 +61,14 @@ class MainWindow(QMainWindow):
     # minimum dock dimension when collapsed/expanded
     MIN_DOCK_SIZE = 1
 
+    def _dock_frame_width(self, dock):
+        """Return the frame width of ``dock`` using the current style."""
+        return dock.style().pixelMetric(QStyle.PM_DockWidgetFrameWidth, None, dock)
+
     def _header_min_size(self, dock, orientation):
         """Return dock header size including frame."""
         header = self.dock_headers.get(dock)
-        frame = dock.frameWidth() * 2
+        frame = self._dock_frame_width(dock) * 2
         if orientation == Qt.Horizontal:
             base = header.sizeHint().width() if header else self.MIN_DOCK_SIZE
         else:
@@ -319,7 +323,7 @@ class MainWindow(QMainWindow):
         )
         dock.setTitleBarWidget(header)
         header_size = header.sizeHint()
-        frame = dock.frameWidth() * 2
+        frame = self._dock_frame_width(dock) * 2
         dock.setMinimumHeight(header_size.height() + frame)
         dock.setMinimumWidth(header_size.width() + frame)
 
@@ -1284,9 +1288,9 @@ class MainWindow(QMainWindow):
                     min_size = self.MIN_DOCK_SIZE
                     if header:
                         if self._split_orientation == Qt.Horizontal:
-                            min_size = header.sizeHint().width() + 2 * new_dock.frameWidth()
+                            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(new_dock)
                         else:
-                            min_size = header.sizeHint().height() + 2 * new_dock.frameWidth()
+                            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(new_dock)
                     if size <= min_size:
                         self._collapse_dock(new_dock, self._split_orientation)
                     else:
@@ -1295,14 +1299,14 @@ class MainWindow(QMainWindow):
                             new_dock.setMaximumWidth(QWIDGETSIZE_MAX)
                             dock_header = self.dock_headers.get(dock)
                             if dock_header:
-                                dock.setMinimumWidth(dock_header.sizeHint().width() + 2 * dock.frameWidth())
+                                dock.setMinimumWidth(dock_header.sizeHint().width() + 2 * self._dock_frame_width(dock))
                             dock.setMaximumWidth(QWIDGETSIZE_MAX)
                         else:
                             new_dock.setMinimumHeight(self._header_min_size(new_dock, Qt.Vertical))
                             new_dock.setMaximumHeight(QWIDGETSIZE_MAX)
                             dock_header = self.dock_headers.get(dock)
                             if dock_header:
-                                dock.setMinimumHeight(dock_header.sizeHint().height() + 2 * dock.frameWidth())
+                                dock.setMinimumHeight(dock_header.sizeHint().height() + 2 * self._dock_frame_width(dock))
                             dock.setMaximumHeight(QWIDGETSIZE_MAX)
                 elif self._split_preview:
                     func = getattr(self, "_update_split_preview", None)
@@ -1661,7 +1665,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -1671,7 +1675,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -1756,7 +1760,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -1766,7 +1770,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -1880,7 +1884,7 @@ class MainWindow(QMainWindow):
             return
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -1888,7 +1892,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -1902,7 +1906,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -1912,7 +1916,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2026,7 +2030,7 @@ class MainWindow(QMainWindow):
             return
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -2034,7 +2038,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2050,7 +2054,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -2060,7 +2064,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2179,7 +2183,7 @@ class MainWindow(QMainWindow):
         # size constraints are based on the original dock header
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -2187,7 +2191,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2203,7 +2207,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -2213,7 +2217,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2334,7 +2338,7 @@ class MainWindow(QMainWindow):
         # size constraints are based on the original dock header
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.x()), total - min_size))
             if delta.x() >= 0:
@@ -2342,7 +2346,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             total = self._split_start_size
             size = max(min_size, min(abs(delta.y()), total - min_size))
             if delta.y() >= 0:
@@ -2358,7 +2362,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             min_size = 1
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - header_size))
@@ -2369,7 +2373,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             min_size = 1
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - header_size))
@@ -2465,9 +2469,9 @@ class MainWindow(QMainWindow):
         header_size = 0
         if header:
             if self._split_orientation == Qt.Horizontal:
-                header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+                header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             else:
-                header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+                header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
         new_dock = self._create_dock(label, area)
         new_dock.hide()
         if self._split_orientation == Qt.Horizontal:
@@ -2504,7 +2508,7 @@ class MainWindow(QMainWindow):
         # size constraints are based on the original dock header
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             min_size = 1
             total = self._split_start_size
             max_size = total - header_size
@@ -2514,7 +2518,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             min_size = 1
             total = self._split_start_size
             max_size = total - header_size
@@ -2532,7 +2536,7 @@ class MainWindow(QMainWindow):
 
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             min_size = header_size
             total = dock.width()
             size = max(min_size, min(abs(delta.x()), total - header_size))
@@ -2543,7 +2547,7 @@ class MainWindow(QMainWindow):
                 preview.new_area.setGeometry(0, 0, size, dock.height())
                 preview.old_area.setGeometry(size, 0, total - size, dock.height())
         else:
-            header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             min_size = header_size
             total = dock.height()
             size = max(min_size, min(abs(delta.y()), total - header_size))
@@ -2639,9 +2643,9 @@ class MainWindow(QMainWindow):
         header_size = 0
         if header:
             if self._split_orientation == Qt.Horizontal:
-                header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+                header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             else:
-                header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+                header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
         new_dock = self._create_dock(label, area)
         new_dock.hide()
         if self._split_orientation == Qt.Horizontal:
@@ -2678,7 +2682,7 @@ class MainWindow(QMainWindow):
         # size constraints are based on the original dock header
         header = self.dock_headers.get(dock)
         if self._split_orientation == Qt.Horizontal:
-            header_size = header.sizeHint().width() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
             min_size = header_size
             total = self._split_start_size
             max_size = total - header_size
@@ -2688,7 +2692,7 @@ class MainWindow(QMainWindow):
             else:
                 self.resizeDocks([new_dock, dock], [size, total - size], Qt.Horizontal)
         else:
-            header_size = header.sizeHint().height() + 2 * dock.frameWidth()
+            header_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
             min_size = header_size
             total = self._split_start_size
             max_size = total - header_size
@@ -2717,7 +2721,7 @@ class MainWindow(QMainWindow):
         header = self.dock_headers.get(dock)
         try:
             if self._split_orientation == Qt.Horizontal:
-                min_size = header.sizeHint().width() + 2 * dock.frameWidth()
+                min_size = header.sizeHint().width() + 2 * self._dock_frame_width(dock)
                 size = max(min_size, min(abs(delta.x()), dock.width() - min_size))
                 if delta.x() >= 0:
                     self.splitDockWidget(dock, new_dock, Qt.Horizontal)
@@ -2726,7 +2730,7 @@ class MainWindow(QMainWindow):
                     self.splitDockWidget(new_dock, dock, Qt.Horizontal)
                     self.resizeDocks([new_dock, dock], [size, dock.width() - size], Qt.Horizontal)
             else:
-                min_size = header.sizeHint().height() + 2 * dock.frameWidth()
+                min_size = header.sizeHint().height() + 2 * self._dock_frame_width(dock)
                 size = max(min_size, min(abs(delta.y()), dock.height() - min_size))
                 if delta.y() >= 0:
                     self.splitDockWidget(dock, new_dock, Qt.Vertical)
@@ -2741,9 +2745,9 @@ class MainWindow(QMainWindow):
         min_size = self.MIN_DOCK_SIZE
         if header_new:
             if self._split_orientation == Qt.Horizontal:
-                min_size = header_new.sizeHint().width() + 2 * new_dock.frameWidth()
+                min_size = header_new.sizeHint().width() + 2 * self._dock_frame_width(new_dock)
             else:
-                min_size = header_new.sizeHint().height() + 2 * new_dock.frameWidth()
+                min_size = header_new.sizeHint().height() + 2 * self._dock_frame_width(new_dock)
         if size <= min_size:
             self._collapse_dock(new_dock, self._split_orientation)
 


### PR DESCRIPTION
## Summary
- fix `AttributeError` when calculating dock frame width
- adjust dock size calculations accordingly

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `python -m compileall -q pictocode`

------
https://chatgpt.com/codex/tasks/task_e_685d4ca010a483239437803d5a38a469