### PR TITLE
Add unified settings with dock color options

### DIFF
--- a/pictocode/ui/__init__.py
+++ b/pictocode/ui/__init__.py
@@ -10,6 +10,7 @@ from .layers_dock import LayersWidget
 from .layout_dock import LayoutWidget
 from .logs_dock import LogsWidget
 from .debug_dialog import DebugDialog
+from .settings_dialog import SettingsDialog
 
 __all__ = [
     "MainWindow",
@@ -21,4 +22,5 @@ __all__ = [
     "LayoutWidget",
     "LogsWidget",
     "DebugDialog",
+    "SettingsDialog",
 ]

--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,13 +1,15 @@
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
 from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QColor
 
 class CornerTabs(QWidget):
     """Dropdown widget used as dock header or floating overlay."""
 
     tab_selected = pyqtSignal(str)
 
-    def __init__(self, parent=None, overlay=False):
+    def __init__(self, parent=None, overlay=False, color: QColor | None = None):
         super().__init__(parent)
+        self._color = QColor(color) if color else None
         self.setObjectName("corner_tabs")
         if overlay:
             self.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint)
@@ -21,6 +23,8 @@ class CornerTabs(QWidget):
         self.selector.currentTextChanged.connect(self._emit_change)
         if overlay:
             self.hide()
+        if self._color:
+            self.set_color(self._color)
 
     def mouseDoubleClickEvent(self, event):
         dock = self.parent()
@@ -51,5 +55,10 @@ class CornerTabs(QWidget):
 
     def _emit_change(self, text):
         self.tab_selected.emit(text)
+
+    def set_color(self, color: QColor):
+        """Apply a background color to the tab bar."""
+        self._color = QColor(color)
+        self.setStyleSheet(f"#corner_tabs {{ background: {self._color.name()}; }}")
 
 

--- a/pictocode/ui/settings_dialog.py
+++ b/pictocode/ui/settings_dialog.py
@@ -1,0 +1,242 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QFormLayout,
+    QDialogButtonBox,
+    QTabWidget,
+    QWidget,
+    QLineEdit,
+    QColorDialog,
+    QComboBox,
+    QSpinBox,
+    QCheckBox,
+    QLabel,
+    QKeySequenceEdit,
+)
+from PyQt5.QtGui import QColor
+from PyQt5.QtCore import Qt
+
+
+class SettingsDialog(QDialog):
+    """Combined preferences dialog with tabs."""
+
+    DOCK_NAMES = ["Propriétés", "Imports", "Objets", "Logs"]
+
+    def __init__(
+        self,
+        shortcuts: dict[str, str],
+        current_theme: str = "Light",
+        accent: QColor | str = QColor(0, 120, 215),
+        font_size: int = 10,
+        menu_color: QColor | str | None = None,
+        toolbar_color: QColor | str | None = None,
+        dock_color: QColor | str | None = None,
+        menu_font_size: int | None = None,
+        toolbar_font_size: int | None = None,
+        dock_font_size: int | None = None,
+        show_splash: bool = True,
+        autosave_enabled: bool = False,
+        autosave_interval: int = 5,
+        auto_show_inspector: bool = True,
+        float_docks: bool = False,
+        dock_title_colors: dict[str, QColor] | None = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Préférences")
+        self.setModal(True)
+
+        dock_title_colors = dock_title_colors or {}
+        self.dock_title_colors = {
+            name: QColor(dock_title_colors.get(name, toolbar_color or accent))
+            for name in self.DOCK_NAMES
+        }
+
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget(self)
+        layout.addWidget(self.tabs)
+
+        # --- General tab -------------------------------------------------
+        gen = QWidget()
+        gen_form = QFormLayout(gen)
+        self.show_splash_chk = QCheckBox()
+        self.show_splash_chk.setChecked(bool(show_splash))
+        gen_form.addRow("Afficher l'écran de démarrage :", self.show_splash_chk)
+
+        self.autosave_chk = QCheckBox()
+        self.autosave_chk.setChecked(bool(autosave_enabled))
+        gen_form.addRow("Sauvegarde auto :", self.autosave_chk)
+
+        self.autosave_spin = QSpinBox()
+        self.autosave_spin.setRange(1, 60)
+        self.autosave_spin.setValue(int(autosave_interval))
+        gen_form.addRow("Intervalle (min) :", self.autosave_spin)
+
+        self.auto_show_chk = QCheckBox()
+        self.auto_show_chk.setChecked(bool(auto_show_inspector))
+        gen_form.addRow("Ouvrir inspecteur sur sélection :", self.auto_show_chk)
+
+        self.float_docks_chk = QCheckBox()
+        self.float_docks_chk.setChecked(bool(float_docks))
+        gen_form.addRow("Fenêtres flottantes :", self.float_docks_chk)
+
+        self.tabs.addTab(gen, "Général")
+
+        # --- Appearance tab ---------------------------------------------
+        app = QWidget()
+        app_form = QFormLayout(app)
+
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItems(["Light", "Dark"])
+        idx = self.theme_combo.findText(current_theme)
+        if idx >= 0:
+            self.theme_combo.setCurrentIndex(idx)
+        app_form.addRow("Thème :", self.theme_combo)
+
+        self.accent_color = QColor(accent)
+        self.color_edit = QLineEdit(self.accent_color.name())
+        self.color_edit.setReadOnly(True)
+        self.color_edit.mousePressEvent = lambda e: self._choose_color("accent")
+        app_form.addRow("Couleur d'accent :", self.color_edit)
+
+        self.font_spin = QSpinBox()
+        self.font_spin.setRange(6, 32)
+        self.font_spin.setValue(int(font_size))
+        app_form.addRow("Taille de police :", self.font_spin)
+
+        self.menu_color = QColor(menu_color or self.accent_color)
+        self.menu_color_edit = QLineEdit(self.menu_color.name())
+        self.menu_color_edit.setReadOnly(True)
+        self.menu_color_edit.mousePressEvent = lambda e: self._choose_color("menu")
+        app_form.addRow("Couleur menu :", self.menu_color_edit)
+
+        self.toolbar_color = QColor(toolbar_color or self.accent_color)
+        self.toolbar_color_edit = QLineEdit(self.toolbar_color.name())
+        self.toolbar_color_edit.setReadOnly(True)
+        self.toolbar_color_edit.mousePressEvent = lambda e: self._choose_color("toolbar")
+        app_form.addRow("Couleur barre d'outils :", self.toolbar_color_edit)
+
+        self.dock_color = QColor(dock_color or self.accent_color)
+        self.dock_color_edit = QLineEdit(self.dock_color.name())
+        self.dock_color_edit.setReadOnly(True)
+        self.dock_color_edit.mousePressEvent = lambda e: self._choose_color("dock")
+        app_form.addRow("Couleur inspecteur :", self.dock_color_edit)
+
+        self.menu_font_spin = QSpinBox()
+        self.menu_font_spin.setRange(6, 32)
+        self.menu_font_spin.setValue(int(menu_font_size or font_size))
+        app_form.addRow("Police menu :", self.menu_font_spin)
+
+        self.toolbar_font_spin = QSpinBox()
+        self.toolbar_font_spin.setRange(6, 32)
+        self.toolbar_font_spin.setValue(int(toolbar_font_size or font_size))
+        app_form.addRow("Police barre d'outils :", self.toolbar_font_spin)
+
+        self.dock_font_spin = QSpinBox()
+        self.dock_font_spin.setRange(6, 32)
+        self.dock_font_spin.setValue(int(dock_font_size or font_size))
+        app_form.addRow("Police inspecteur :", self.dock_font_spin)
+
+        # per dock title colors
+        self._dock_color_edits = {}
+        for name in self.DOCK_NAMES:
+            col = self.dock_title_colors[name]
+            edit = QLineEdit(col.name())
+            edit.setReadOnly(True)
+            edit.mousePressEvent = lambda e, n=name: self._choose_dock_color(n)
+            app_form.addRow(f"Couleur {name} :", edit)
+            self._dock_color_edits[name] = edit
+
+        self.tabs.addTab(app, "Apparence")
+
+        # --- Shortcuts tab ----------------------------------------------
+        sh = QWidget()
+        sh_form = QFormLayout(sh)
+        self._short_edits = {}
+        for name, seq in shortcuts.items():
+            edit = QKeySequenceEdit(seq, self)
+            sh_form.addRow(name + " :", edit)
+            self._short_edits[name] = edit
+        self.tabs.addTab(sh, "Raccourcis")
+
+        # --- Credits tab -------------------------------------------------
+        cr = QWidget()
+        cr_layout = QVBoxLayout(cr)
+        cr_label = QLabel("Pictocode\n(c) 2023")
+        cr_label.setAlignment(Qt.AlignCenter)
+        cr_layout.addWidget(cr_label)
+        cr_layout.addStretch()
+        self.tabs.addTab(cr, "Crédits")
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    # --- internals ------------------------------------------------------
+    def _choose_color(self, target):
+        current = getattr(self, f"{target}_color")
+        col = QColorDialog.getColor(current, self)
+        if col.isValid():
+            setattr(self, f"{target}_color", col)
+            getattr(self, f"{target}_color_edit").setText(col.name())
+
+    def _choose_dock_color(self, name):
+        col = QColorDialog.getColor(self.dock_title_colors[name], self)
+        if col.isValid():
+            self.dock_title_colors[name] = col
+            self._dock_color_edits[name].setText(col.name())
+
+    # --- accessors ------------------------------------------------------
+    def get_theme(self) -> str:
+        return self.theme_combo.currentText()
+
+    def get_accent_color(self) -> QColor:
+        return self.accent_color
+
+    def get_font_size(self) -> int:
+        return self.font_spin.value()
+
+    def get_menu_color(self) -> QColor:
+        return self.menu_color
+
+    def get_toolbar_color(self) -> QColor:
+        return self.toolbar_color
+
+    def get_dock_color(self) -> QColor:
+        return self.dock_color
+
+    def get_menu_font_size(self) -> int:
+        return self.menu_font_spin.value()
+
+    def get_toolbar_font_size(self) -> int:
+        return self.toolbar_font_spin.value()
+
+    def get_dock_font_size(self) -> int:
+        return self.dock_font_spin.value()
+
+    def get_show_splash(self) -> bool:
+        return self.show_splash_chk.isChecked()
+
+    def get_autosave_enabled(self) -> bool:
+        return self.autosave_chk.isChecked()
+
+    def get_autosave_interval(self) -> int:
+        return self.autosave_spin.value()
+
+    def get_auto_show_inspector(self) -> bool:
+        return self.auto_show_chk.isChecked()
+
+    def get_float_docks(self) -> bool:
+        return self.float_docks_chk.isChecked()
+
+    def get_dock_title_colors(self) -> dict[str, QColor]:
+        return self.dock_title_colors
+
+    def get_shortcuts(self) -> dict[str, str]:
+        return {
+            name: edit.keySequence().toString()
+            for name, edit in self._short_edits.items()
+        }


### PR DESCRIPTION
## Summary
- add `SettingsDialog` combining appearance and shortcut settings with dock title color customization
- expose new dialog in `ui.__init__`
- allow setting colors for dock headers via `CornerTabs`
- read and save individual dock title colors in `MainWindow`
- replace separate Appearance/Shortcut actions with single Preferences action
- **fix initialization of dock title colors before creating docks**
- reduce collapsed dock height to combo box size

## Testing
- `python -m py_compile pictocode/ui/main_window.py pictocode/ui/settings_dialog.py pictocode/ui/corner_tabs.py`


------
https://chatgpt.com/codex/tasks/task_e_685d4f68b7148323aeb7c08d81d14769