### PR TITLE
Collapse docks to header height

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
+from ..utils import get_contrast_color
 
 class CornerTabs(QWidget):
     """Dropdown widget used as dock header or floating overlay."""
@@ -18,15 +19,22 @@ class CornerTabs(QWidget):
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignLeft)
         self.selector = QComboBox(self)
+        self.selector.setObjectName("corner_selector")
         self.selector.addItems(["Propriétés", "Imports", "Objets", "Logs"])
         layout.addWidget(self.selector)
         layout.addStretch()
-        self.setFixedHeight(self.selector.sizeHint().height())
         self.selector.currentTextChanged.connect(self._emit_change)
-        if overlay:
-            self.hide()
         if self._color:
             self.set_color(self._color)
+        else:
+            base_style = (
+                "QComboBox#corner_selector { border: none; padding: 0 6px; }"
+                "QComboBox#corner_selector::drop-down { border: none; }"
+            )
+            self.setStyleSheet(base_style)
+        self.setFixedHeight(self.selector.sizeHint().height())
+        if overlay:
+            self.hide()
 
     def mouseDoubleClickEvent(self, event):
         dock = self.parent()
@@ -61,6 +69,14 @@ class CornerTabs(QWidget):
     def set_color(self, color: QColor):
         """Apply a background color to the tab bar."""
         self._color = QColor(color)
-        self.setStyleSheet(f"#corner_tabs {{ background: {self._color.name()}; }}")
+        text = get_contrast_color(self._color)
+        style = (
+            f"#corner_tabs {{ background: {self._color.name()}; }}"\
+            f"QComboBox#corner_selector {{ border: none; padding: 0 6px;"\
+            f" background: transparent; color: {text}; }}"\
+            "QComboBox#corner_selector::drop-down { border: none; }"
+        )
+        self.setStyleSheet(style)
+        self.setFixedHeight(self.selector.sizeHint().height())
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -16,7 +16,6 @@ from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
     QToolBar,
-    QHBoxLayout,
     QWIDGETSIZE_MAX,
     QStyle,
 )
@@ -323,17 +322,16 @@ class MainWindow(QMainWindow):
         container = QWidget()
         lay = QVBoxLayout(container)
         lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(0)
         widget = self.category_widgets[label]
         lay.addWidget(widget)
-        handle_layout = QHBoxLayout()
-        handle_layout.setContentsMargins(0, 0, 2, 2)
-        handle_layout.addStretch()
-        handle = CornerHandle(container)
-        handle_layout.addWidget(handle)
-        handle.installEventFilter(self)
-        lay.addLayout(handle_layout)
         container.setLayout(lay)
         dock.setWidget(container)
+
+        handle = CornerHandle(header)
+        handle.installEventFilter(self)
+        header.layout().addWidget(handle)
+        header.layout().setAlignment(handle, Qt.AlignRight | Qt.AlignVCenter)
         if self.float_docks:
             dock.setAllowedAreas(Qt.NoDockWidgetArea)
         else:
@@ -1130,17 +1128,19 @@ class MainWindow(QMainWindow):
             QWidget#corner_handle {{
                 background: transparent;
             }}
+            QDockWidget::title {{
+                padding: 0px;
+                margin: 0px;
+            }}
             """
         )
         self.inspector.setStyleSheet(f"font-size: {dock_font_size}pt;")
         for dock in self.docks:
             style = (
                 f"QDockWidget {{ background: {dock_color.name()}; border: none; }}"
+                "QDockWidget::title { padding: 0px; margin: 0px; }"
             )
             dock.setStyleSheet(style)
-            dock.setStyleSheet(
-                f"QDockWidget {{ background: {dock_color.name()}; border: none; }}"
-            )
             widget = dock.widget()
             if widget:
                 widget.setStyleSheet(f"font-size: {dock_font_size}pt;")
@@ -1401,25 +1401,20 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
-        size = self._header_min_size(dock, orientation)
-        if orientation == Qt.Horizontal:
-            dock.setMinimumWidth(size)
-            dock.setMaximumWidth(size)
-        else:
-            dock.setMinimumHeight(size)
-            dock.setMaximumHeight(size)
+        size = self._header_min_size(dock, Qt.Vertical)
+        dock.setMinimumHeight(size)
+        dock.setMaximumHeight(size)
+        dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
-        orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
-        min_size = self._header_min_size(dock, orientation)
-        if orientation == Qt.Horizontal:
-            dock.setMinimumWidth(min_size)
-            dock.setMaximumWidth(QWIDGETSIZE_MAX)
-        else:
-            dock.setMinimumHeight(min_size)
-            dock.setMaximumHeight(QWIDGETSIZE_MAX)
+        min_size = self._header_min_size(dock, Qt.Vertical)
+        dock.setMinimumHeight(min_size)
+        dock.setMaximumHeight(QWIDGETSIZE_MAX)
+        restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+        dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -1428,12 +1423,7 @@ class MainWindow(QMainWindow):
         if getattr(dock, "_collapsed", False):
             self._expand_dock(dock)
         else:
-            area = self.dockWidgetArea(dock)
-            if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):
-                orientation = Qt.Horizontal
-            else:
-                orientation = Qt.Vertical
-            self._collapse_dock(dock, orientation)
+            self._collapse_dock(dock, Qt.Vertical)
 
     def show_corner_tabs(self):
         """Display a floating tab selector near the cursor."""
@@ -1529,15 +1519,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1545,9 +1541,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -1679,15 +1679,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1695,9 +1701,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -1778,15 +1788,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1794,9 +1810,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -1928,15 +1948,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1944,9 +1970,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -2080,15 +2110,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -2096,9 +2132,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -2237,15 +2277,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -2253,9 +2299,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -2398,15 +2448,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -2414,9 +2470,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -2576,15 +2636,21 @@ class MainWindow(QMainWindow):
     def _collapse_dock(self, dock, orientation):
         dock._collapsed = True
         dock._collapse_orientation = orientation
+        if orientation == Qt.Horizontal:
+            dock._restore_size = dock.width()
+        else:
+            dock._restore_size = dock.height()
         if dock.widget():
             dock.widget().hide()
         size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(size)
             dock.setMaximumWidth(size)
+            dock.resize(size, dock.height())
         else:
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
+            dock.resize(dock.width(), size)
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -2592,9 +2658,13 @@ class MainWindow(QMainWindow):
         if orientation == Qt.Horizontal:
             dock.setMinimumWidth(min_size)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(restore, dock.height())
         else:
             dock.setMinimumHeight(min_size)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
+            restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
+            dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
@@ -2782,20 +2852,19 @@ class MainWindow(QMainWindow):
         if prev and prev is not dock:
             cont = prev.widget()
             lay = cont.layout()
-            if lay.count() > 1:
-                old = lay.itemAt(1).widget()
+            if lay.count():
+                old = lay.itemAt(0).widget()
                 if old is widget:
                     old.setParent(None)
-                lay.insertWidget(1, QWidget())
             self.dock_current_widget[prev] = None
         # insert into new dock
         cont = dock.widget()
         lay = cont.layout()
-        if lay.count() > 1:
-            old = lay.itemAt(1).widget()
+        if lay.count():
+            old = lay.itemAt(0).widget()
             if old:
                 old.setParent(None)
-        lay.insertWidget(1, widget)
+        lay.insertWidget(0, widget)
         self.widget_docks[widget] = dock
         self.dock_current_widget[dock] = widget
         dock.setWindowTitle(label)


### PR DESCRIPTION
## Summary
- collapse docks vertically so only the title bar remains visible

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685d7e9be0a08323a4ae33485757a05e