### PR TITLE
Collapse docks to header height

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
+from ..utils import get_contrast_color
 
 class CornerTabs(QWidget):
     """Dropdown widget used as dock header or floating overlay."""
@@ -18,15 +19,28 @@ class CornerTabs(QWidget):
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignLeft)
         self.selector = QComboBox(self)
-        self.selector.addItems(["Propriétés", "Imports", "Objets", "Logs"])
+        self.selector.setObjectName("corner_selector")
+        self.selector.addItems([
+            "Plan de travail",
+            "Propriétés",
+            "Imports",
+            "Objets",
+            "Logs",
+        ])
         layout.addWidget(self.selector)
         layout.addStretch()
-        self.setFixedHeight(self.selector.sizeHint().height())
         self.selector.currentTextChanged.connect(self._emit_change)
-        if overlay:
-            self.hide()
         if self._color:
             self.set_color(self._color)
+        else:
+            base_style = (
+                "QComboBox#corner_selector { border: none; padding: 0 6px; }"
+                "QComboBox#corner_selector::drop-down { border: none; }"
+            )
+            self.setStyleSheet(base_style)
+        self.setFixedHeight(self.selector.sizeHint().height())
+        if overlay:
+            self.hide()
 
     def mouseDoubleClickEvent(self, event):
         dock = self.parent()
@@ -61,6 +75,14 @@ class CornerTabs(QWidget):
     def set_color(self, color: QColor):
         """Apply a background color to the tab bar."""
         self._color = QColor(color)
-        self.setStyleSheet(f"#corner_tabs {{ background: {self._color.name()}; }}")
+        text = get_contrast_color(self._color)
+        style = (
+            f"#corner_tabs {{ background: {self._color.name()}; }}"\
+            f"QComboBox#corner_selector {{ border: none; padding: 0 6px;"\
+            f" background: transparent; color: {text}; }}"\
+            "QComboBox#corner_selector::drop-down { border: none; }"
+        )
+        self.setStyleSheet(style)
+        self.setFixedHeight(self.selector.sizeHint().height())
 
 


### PR DESCRIPTION
## Summary
- collapse docks vertically so only the title bar remains visible
- allow computing header size using actual widget height
- ensure resize handle sits flush with the bottom-right corner
- add a `Plan de travail` tab category and remove default dock size limits

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685d7e9be0a08323a4ae33485757a05e