### PR TITLE
Update corner handle placement

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -115,7 +115,7 @@ class CornerTabs(QWidget):
         if self._handle:
             self._handle.move(
                 self.width() - self._handle.width(),
-                self.height() - self._handle.height(),
+                0,
             )
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -1259,7 +1259,12 @@ class MainWindow(QMainWindow):
                 else:
                     pos = obj.mapTo(dock, event.pos())
                 r = dock.rect()
-                corner = r.adjusted(r.width() - self.CORNER_REGION, r.height() - self.CORNER_REGION, 0, 0)
+                corner = QRect(
+                    r.width() - self.CORNER_REGION,
+                    0,
+                    self.CORNER_REGION,
+                    self.CORNER_REGION,
+                )
                 if corner.contains(pos):
                     self._corner_dragging = True
                     self._corner_dragging_dock = dock


### PR DESCRIPTION
## Summary
- move the corner handle to the top right of tab headers
- adjust detection area for dragging to match new handle location

## Testing
- `python -m compileall -q pictocode`

------
https://chatgpt.com/codex/tasks/task_e_685e1bd8d814832383f846f7a86d0fb5