### PR TITLE
Update corner handle placement

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -3,18 +3,6 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
 from ..utils import get_contrast_color
 
-from ..utils import get_contrast_color
-
-from ..utils import get_contrast_color
-
-from ..utils import get_contrast_color
-
-from ..utils import get_contrast_color
-
-from ..utils import get_contrast_color
-
-from ..utils import get_contrast_color
-
 class CornerTabs(QWidget):
     """Dropdown widget used as dock header or floating overlay."""
 
@@ -101,7 +89,7 @@ class CornerTabs(QWidget):
     # ------------------------------------------------------------------
     # Resize handle support
     def set_handle(self, handle: QWidget):
-        """Attach ``handle`` and keep it aligned to the bottom-right."""
+        """Attach ``handle`` and keep it aligned to the top-right."""
         self._handle = handle
         handle.setParent(self)
         handle.raise_()
@@ -115,7 +103,7 @@ class CornerTabs(QWidget):
         if self._handle:
             self._handle.move(
                 self.width() - self._handle.width(),
-                self.height() - self._handle.height(),
+                0,
             )
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -336,15 +336,10 @@ class MainWindow(QMainWindow):
         dock.setMinimumHeight(combo_size.height() + frame)
         dock.setMinimumWidth(combo_size.width() + frame)
 
-        handle = CornerHandle()
+        handle = CornerHandle(header)
         handle.installEventFilter(self)
         header.set_handle(handle)
         dock.setWidget(container)
-
-        handle = CornerHandle(header)
-        handle.installEventFilter(self)
-        header.layout().addWidget(handle)
-        header.layout().setAlignment(handle, Qt.AlignRight | Qt.AlignBottom)
         if self.float_docks:
             dock.setAllowedAreas(Qt.NoDockWidgetArea)
         else:
@@ -1259,7 +1254,12 @@ class MainWindow(QMainWindow):
                 else:
                     pos = obj.mapTo(dock, event.pos())
                 r = dock.rect()
-                corner = r.adjusted(r.width() - self.CORNER_REGION, r.height() - self.CORNER_REGION, 0, 0)
+                corner = QRect(
+                    r.width() - self.CORNER_REGION,
+                    0,
+                    self.CORNER_REGION,
+                    self.CORNER_REGION,
+                )
                 if corner.contains(pos):
                     self._corner_dragging = True
                     self._corner_dragging_dock = dock


### PR DESCRIPTION
## Summary
- keep only a single handle for each dock header
- remove redundant imports and update documentation
- adjust `_create_dock` implementation for clarity

## Testing
- `python -m compileall -q pictocode`


------
https://chatgpt.com/codex/tasks/task_e_685e1bd8d814832383f846f7a86d0fb5