### PR TITLE
Fix resize handle position and improve dock collapse

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -101,9 +101,11 @@ class CornerTabs(QWidget):
 
     def _position_handle(self):
         if self._handle:
-            self._handle.move(
-                self.width() - self._handle.width(),
-                0,
-            )
+            dock = self.parent()
+            if dock is not None:
+                self._handle.move(
+                    dock.width() - self._handle.width(),
+                    dock.height() - self._handle.height(),
+                )
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -1248,6 +1248,9 @@ class MainWindow(QMainWindow):
                         content.hide()
                     else:
                         content.show()
+                header = self.dock_headers.get(dock)
+                if header:
+                    header._position_handle()
             elif event.type() == QEvent.MouseButtonPress and event.button() == Qt.LeftButton:
                 if obj is dock:
                     pos = event.pos()


### PR DESCRIPTION
## Summary
- move corner handle to the bottom-right of floating docks
- keep handle aligned when docks are resized

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e249b16b083239e5e69c2218f6d92