### PR TITLE
Fix dock handle placement and collapse

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -101,9 +101,11 @@ class CornerTabs(QWidget):
 
     def _position_handle(self):
         if self._handle:
-            self._handle.move(
-                self.width() - self._handle.width(),
-                0,
-            )
+            dock = self.parent()
+            if dock is not None:
+                self._handle.move(
+                    dock.width() - self._handle.width(),
+                    self.height(),
+                )
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -1248,15 +1248,20 @@ class MainWindow(QMainWindow):
                         content.hide()
                     else:
                         content.show()
+                header = self.dock_headers.get(dock)
+                if header:
+                    header._position_handle()
             elif event.type() == QEvent.MouseButtonPress and event.button() == Qt.LeftButton:
                 if obj is dock:
                     pos = event.pos()
                 else:
                     pos = obj.mapTo(dock, event.pos())
                 r = dock.rect()
+                header = self.dock_headers.get(dock)
+                header_h = header.height() if header else 0
                 corner = QRect(
                     r.width() - self.CORNER_REGION,
-                    0,
+                    header_h,
                     self.CORNER_REGION,
                     self.CORNER_REGION,
                 )
@@ -1422,6 +1427,9 @@ class MainWindow(QMainWindow):
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
             dock.resize(dock.width(), size)
+        header = self.dock_headers.get(dock)
+        if header:
+            header._position_handle()
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1439,6 +1447,9 @@ class MainWindow(QMainWindow):
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
+        header = self.dock_headers.get(dock)
+        if header:
+            header._position_handle()
 
     def _toggle_dock(self, dock):
         if getattr(dock, "_collapsed", False):


### PR DESCRIPTION
## Summary
- position dock resize handle beneath the tab bar
- detect handle drag below header
- keep handle aligned when docks collapse or expand

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e249b16b083239e5e69c2218f6d92