### PR TITLE
Improve dock resize handle

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,4 +1,11 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
+from PyQt5.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QComboBox,
+    QMenu,
+    QDockWidget,
+    QStyle,
+)
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
 from ..utils import get_contrast_color
@@ -89,10 +96,15 @@ class CornerTabs(QWidget):
     # ------------------------------------------------------------------
     # Resize handle support
     def set_handle(self, handle: QWidget):
-        """Attach ``handle`` and keep it aligned to the top-right."""
+        """Attach ``handle`` and keep it aligned just below the title bar."""
         self._handle = handle
-        handle.setParent(self)
+        dock = self.parent()
+        if isinstance(dock, QDockWidget):
+            handle.setParent(dock)
+        else:
+            handle.setParent(self)
         handle.raise_()
+        handle.show()
         self._position_handle()
 
     def resizeEvent(self, event):
@@ -100,10 +112,23 @@ class CornerTabs(QWidget):
         self._position_handle()
 
     def _position_handle(self):
+        if not self._handle:
+            return
+        dock = self.parent()
+        if isinstance(dock, QDockWidget):
+            frame = dock.style().pixelMetric(QStyle.PM_DockWidgetFrameWidth, None, dock)
+            x = dock.width() - self._handle.width() - frame
+            y = self.height() + frame
+        else:
+            x = self.width() - self._handle.width()
+            y = self.height()
+        self._handle.move(x, y)
+        self._handle.raise_()
+
+    def show_handle(self, visible: bool = True):
         if self._handle:
-            self._handle.move(
-                self.width() - self._handle.width(),
-                0,
-            )
+            self._handle.setVisible(visible)
+            if visible:
+                self._handle.raise_()
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -336,7 +336,7 @@ class MainWindow(QMainWindow):
         dock.setMinimumHeight(combo_size.height() + frame)
         dock.setMinimumWidth(combo_size.width() + frame)
 
-        handle = CornerHandle(header)
+        handle = CornerHandle(dock)
         handle.installEventFilter(self)
         header.set_handle(handle)
         dock.setWidget(container)
@@ -1248,15 +1248,21 @@ class MainWindow(QMainWindow):
                         content.hide()
                     else:
                         content.show()
+                header = self.dock_headers.get(dock)
+                if header:
+                    header._position_handle()
             elif event.type() == QEvent.MouseButtonPress and event.button() == Qt.LeftButton:
                 if obj is dock:
                     pos = event.pos()
                 else:
                     pos = obj.mapTo(dock, event.pos())
                 r = dock.rect()
+                header = self.dock_headers.get(dock)
+                frame = self._dock_frame_width(dock)
+                header_h = (header.height() if header else 0) + frame
                 corner = QRect(
-                    r.width() - self.CORNER_REGION,
-                    0,
+                    r.width() - self.CORNER_REGION - frame,
+                    header_h,
                     self.CORNER_REGION,
                     self.CORNER_REGION,
                 )
@@ -1422,6 +1428,10 @@ class MainWindow(QMainWindow):
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
             dock.resize(dock.width(), size)
+        header = self.dock_headers.get(dock)
+        if header:
+            header.show_handle(False)
+            header._position_handle()
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
@@ -1439,6 +1449,10 @@ class MainWindow(QMainWindow):
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
+        header = self.dock_headers.get(dock)
+        if header:
+            header.show_handle(True)
+            header._position_handle()
 
     def _toggle_dock(self, dock):
         if getattr(dock, "_collapsed", False):


### PR DESCRIPTION
## Summary
- refine handle positioning with style metrics
- hide handle when a dock collapses and restore on expand

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e249b16b083239e5e69c2218f6d92