### PR TITLE
Fix handle visibility when docks shrink

### DIFF
--- a/pictocode/ui/corner_tabs.py
+++ b/pictocode/ui/corner_tabs.py
@@ -1,4 +1,11 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QMenu, QDockWidget
+from PyQt5.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QComboBox,
+    QMenu,
+    QDockWidget,
+    QStyle,
+)
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
 from ..utils import get_contrast_color
@@ -89,9 +96,12 @@ class CornerTabs(QWidget):
     # ------------------------------------------------------------------
     # Resize handle support
     def set_handle(self, handle: QWidget):
-        """Attach ``handle`` and keep it aligned to the top-right."""
+        """Attach ``handle`` and position it just below the title bar."""
         self._handle = handle
-        handle.setParent(self)
+        dock = self.parent()
+        if handle.parent() is not dock:
+            handle.setParent(dock)
+        handle.show()
         handle.raise_()
         self._position_handle()
 
@@ -101,9 +111,18 @@ class CornerTabs(QWidget):
 
     def _position_handle(self):
         if self._handle:
+            dock = self.parent()
+            frame = dock.style().pixelMetric(QStyle.PM_DockWidgetFrameWidth, None, dock)
             self._handle.move(
-                self.width() - self._handle.width(),
-                0,
+                dock.width() - self._handle.width() - frame,
+                self.height() + frame,
             )
+            self._handle.raise_()
+
+    def show_handle(self, visible: bool = True):
+        if self._handle:
+            self._handle.setVisible(visible)
+            if visible:
+                self._handle.raise_()
 
 

--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -58,7 +58,7 @@ class MainWindow(QMainWindow):
     EDGE_MARGIN = 6
     CORNER_REGION = 20
     # minimum dock dimension when collapsed/expanded
-    MIN_DOCK_SIZE = 1
+    MIN_DOCK_SIZE = 0
 
     def _dock_frame_width(self, dock):
         """Return the frame width of ``dock`` using the current style."""
@@ -70,10 +70,11 @@ class MainWindow(QMainWindow):
         frame = self._dock_frame_width(dock) * 2
         if not header:
             return self.MIN_DOCK_SIZE + frame
+        hint = header.sizeHint()
         if orientation == Qt.Horizontal:
-            base = header.width()
+            base = hint.width()
         else:
-            base = header.height()
+            base = hint.height()
         return base + frame
     # ensure drag related attributes exist before __init__ runs
     _corner_current_dock = None
@@ -333,10 +334,10 @@ class MainWindow(QMainWindow):
         container.setLayout(lay)
 
         combo_size = header.selector.sizeHint()
-        dock.setMinimumHeight(combo_size.height() + frame)
-        dock.setMinimumWidth(combo_size.width() + frame)
+        dock.setMinimumHeight(self.MIN_DOCK_SIZE)
+        dock.setMinimumWidth(self.MIN_DOCK_SIZE)
 
-        handle = CornerHandle(header)
+        handle = CornerHandle(dock)
         handle.installEventFilter(self)
         header.set_handle(handle)
         dock.setWidget(container)
@@ -1234,29 +1235,35 @@ class MainWindow(QMainWindow):
 
                 QTimer.singleShot(0, restore)
             elif event.type() == QEvent.Resize and obj is dock:
-                area = self.dockWidgetArea(dock)
-                if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):
-                    orient = Qt.Horizontal
-                    size = dock.width()
-                else:
-                    orient = Qt.Vertical
-                    size = dock.height()
-                header_size = self._header_min_size(dock, orient)
+                # Always evaluate against the vertical size so docks can
+                # collapse down to just the header regardless of placement
+                size = dock.height()
+                header_size = self._header_min_size(dock, Qt.Vertical)
                 content = dock.widget()
                 if content and not getattr(dock, "_collapsed", False):
                     if size <= header_size:
                         content.hide()
                     else:
                         content.show()
+                header = self.dock_headers.get(dock)
+                if header:
+                    if size <= header_size:
+                        header.show_handle(False)
+                    else:
+                        header.show_handle(True)
+                    header._position_handle()
             elif event.type() == QEvent.MouseButtonPress and event.button() == Qt.LeftButton:
                 if obj is dock:
                     pos = event.pos()
                 else:
                     pos = obj.mapTo(dock, event.pos())
                 r = dock.rect()
+                header = self.dock_headers.get(dock)
+                frame = self._dock_frame_width(dock)
+                header_h = (header.height() if header else 0) + frame
                 corner = QRect(
-                    r.width() - self.CORNER_REGION,
-                    0,
+                    r.width() - self.CORNER_REGION - frame,
+                    header_h - self.CORNER_REGION,
                     self.CORNER_REGION,
                     self.CORNER_REGION,
                 )
@@ -1422,34 +1429,38 @@ class MainWindow(QMainWindow):
             dock.setMinimumHeight(size)
             dock.setMaximumHeight(size)
             dock.resize(dock.width(), size)
+        header = self.dock_headers.get(dock)
+        if header:
+            header.show_handle(False)
+            header._position_handle()
 
     def _expand_dock(self, dock):
         orientation = getattr(dock, "_collapse_orientation", Qt.Horizontal)
         min_size = self._header_min_size(dock, orientation)
         if orientation == Qt.Horizontal:
-            dock.setMinimumWidth(min_size)
+            dock.setMinimumWidth(self.MIN_DOCK_SIZE)
             dock.setMaximumWidth(QWIDGETSIZE_MAX)
             restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
             dock.resize(restore, dock.height())
         else:
-            dock.setMinimumHeight(min_size)
+            dock.setMinimumHeight(self.MIN_DOCK_SIZE)
             dock.setMaximumHeight(QWIDGETSIZE_MAX)
             restore = max(min_size, getattr(dock, "_restore_size", self.default_dock_size))
             dock.resize(dock.width(), restore)
         if dock.widget():
             dock.widget().show()
         dock._collapsed = False
+        header = self.dock_headers.get(dock)
+        if header:
+            header.show_handle(True)
+            header._position_handle()
 
     def _toggle_dock(self, dock):
         if getattr(dock, "_collapsed", False):
             self._expand_dock(dock)
         else:
-            area = self.dockWidgetArea(dock)
-            if area in (Qt.LeftDockWidgetArea, Qt.RightDockWidgetArea):
-                orientation = Qt.Horizontal
-            else:
-                orientation = Qt.Vertical
-            self._collapse_dock(dock, orientation)
+            # Always collapse vertically so only the header remains visible
+            self._collapse_dock(dock, Qt.Vertical)
 
     def show_corner_tabs(self):
         """Display a floating tab selector near the cursor."""


### PR DESCRIPTION
## Summary
- tweak `_header_min_size` to rely on the selector's size
- hide or show the resize handle depending on dock size
- allow collapsing docks vertically
- always compare vertical size during resize to fully hide dock contents

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e249b16b083239e5e69c2218f6d92