### PR TITLE
Improve home screen style

### DIFF
--- a/pictocode/ui/home_page.py
+++ b/pictocode/ui/home_page.py
@@ -142,8 +142,7 @@ class HomePage(QWidget):
         self.setStyleSheet(
             """
             QWidget#home {
-                background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-                    stop:0 #374ABE, stop:1 #64B6FF);
+                background: #1b1b1b;
             }
             QLabel#title_label {
                 font-size: 26px;
@@ -159,9 +158,9 @@ class HomePage(QWidget):
             QListWidget#favorites_list,
             QListWidget#recent_list,
             QListWidget#template_list {
-                background: rgba(255, 255, 255, 0.9);
-                border-radius: 10px;
-                padding: 8px;
+                background: transparent;
+                border: none;
+                padding: 4px;
                 outline: none;
             }
             QListWidget#template_list {
@@ -232,7 +231,7 @@ class HomePage(QWidget):
                 ratio_w = int(128 * w / h)
                 tile = ProjectTile(thumb, display, ratio_w, 128)
             item = QListWidgetItem()
-            item.setSizeHint(tile.sizeHint())
+            tile.set_item(item)
             item.setData(Qt.UserRole, path)
             widget.addItem(item)
             widget.setItemWidget(item, tile)

--- a/pictocode/ui/project_tile.py
+++ b/pictocode/ui/project_tile.py
@@ -1,9 +1,9 @@
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout
+from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout, QListWidgetItem
 from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 
 class ProjectTile(QWidget):
-    """Widget affichant une miniature de projet avec un overlay au survol."""
+    """Widget affichant une miniature de projet avec overlay et titre au survol."""
 
     def __init__(
         self,
@@ -16,36 +16,83 @@ class ProjectTile(QWidget):
         super().__init__(parent)
         self._width = int(width)
         self._height = int(height or width)
+        self._item: QListWidgetItem | None = None
+
+        self.setObjectName("project_tile")
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        self.title_label = QLabel(title, self)
+        self.title_label.setObjectName("tile_title")
+        self.title_label.setAlignment(Qt.AlignCenter)
+        self.title_label.hide()
+        layout.addWidget(self.title_label)
+
         self.preview = QLabel(self)
+        self.preview.setObjectName("tile_preview")
         self.preview.setFixedSize(self._width, self._height)
         self.preview.setPixmap(icon.pixmap(self._width, self._height))
         self.preview.setAlignment(Qt.AlignCenter)
         self.preview.setScaledContents(True)
         layout.addWidget(self.preview)
 
-        self.overlay = QLabel(title, self)
-        self.overlay.setAlignment(Qt.AlignCenter)
-        self.overlay.setStyleSheet(
-            "background-color: rgba(0, 0, 0, 120); color: white;"
-        )
-        self.overlay.hide()
-
-    def enterEvent(self, event):
-        self.overlay.setGeometry(0, 0, self.width(), self.height())
+        self.overlay = QLabel(self.preview)
+        self.overlay.setObjectName("tile_overlay")
+        self.overlay.setGeometry(self.preview.rect())
         self.overlay.show()
+        self.overlay.raise_()
+
+        self.setStyleSheet(
+            """
+            #project_tile {
+                background: #b04848;
+                border-radius: 18px;
+            }
+            QLabel#tile_preview {
+                border-radius: 18px;
+            }
+            QLabel#tile_overlay {
+                background-color: rgba(0, 0, 0, 150);
+                border-radius: 18px;
+            }
+            QLabel#tile_title {
+                color: white;
+                font-weight: bold;
+            }
+            """
+        )
+    def set_item(self, item: QListWidgetItem):
+        """Assure que la taille de l'item suit celle du widget."""
+        self._item = item
+        item.setSizeHint(self.sizeHint())
+
+    # ------------------------------------------------------------------
+    # Events
+    def enterEvent(self, event):
+        self.overlay.hide()
+        self.title_label.show()
+        self._update_item_size()
         super().enterEvent(event)
 
     def leaveEvent(self, event):
-        self.overlay.hide()
+        self.overlay.show()
+        self.title_label.hide()
+        self._update_item_size()
         super().leaveEvent(event)
 
     def resizeEvent(self, event):
-        self.overlay.setGeometry(0, 0, self.width(), self.height())
+        self.overlay.setGeometry(self.preview.rect())
         super().resizeEvent(event)
 
-    def sizeHint(self):
-        return self.preview.size()
+    # ------------------------------------------------------------------
+    def sizeHint(self) -> QSize:
+        h = self._height
+        if self.title_label.isVisible():
+            h += self.title_label.sizeHint().height()
+        return QSize(self._width, h)
+
+    def _update_item_size(self):
+        if self._item is not None:
+            self._item.setSizeHint(self.sizeHint())


### PR DESCRIPTION
## Summary
- darken home page background and lists
- give project tiles a red theme and dynamic sizing
- sync list item sizes with tile hover effects

## Testing
- `python -m compileall -q pictocode/ui`


------
https://chatgpt.com/codex/tasks/task_e_685fb6c8cd608323a2023b073461be78