### PR TITLE
Show project title above tile

### DIFF
--- a/pictocode/ui/home_page.py
+++ b/pictocode/ui/home_page.py
@@ -75,15 +75,7 @@ class HomePage(QWidget):
         # Layout principal
         vbox = QVBoxLayout(self)
 
-        title = QLabel("🎨 Bienvenue sur Pictocode")
-        title.setObjectName("title_label")
-        title.setAlignment(Qt.AlignCenter)
-        vbox.addWidget(title)
-
-        subtitle = QLabel("Créez et gérez vos projets graphiques")
-        subtitle.setAlignment(Qt.AlignCenter)
-        subtitle.setObjectName("subtitle_label")
-        vbox.addWidget(subtitle)
+        # Titre et sous-titre supprimes pour un affichage epure
 
         body = QHBoxLayout()
         vbox.addLayout(body)
@@ -142,26 +134,14 @@ class HomePage(QWidget):
         self.setStyleSheet(
             """
             QWidget#home {
-                background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-                    stop:0 #374ABE, stop:1 #64B6FF);
-            }
-            QLabel#title_label {
-                font-size: 26px;
-                font-weight: bold;
-                color: white;
-                padding: 20px;
-            }
-            QLabel#subtitle_label {
-                font-size: 16px;
-                color: white;
-                padding-bottom: 16px;
+                background: #1b1b1b;
             }
             QListWidget#favorites_list,
             QListWidget#recent_list,
             QListWidget#template_list {
-                background: rgba(255, 255, 255, 0.9);
-                border-radius: 10px;
-                padding: 8px;
+                background: transparent;
+                border: none;
+                padding: 4px;
                 outline: none;
             }
             QListWidget#template_list {
@@ -232,7 +212,7 @@ class HomePage(QWidget):
                 ratio_w = int(128 * w / h)
                 tile = ProjectTile(thumb, display, ratio_w, 128)
             item = QListWidgetItem()
-            item.setSizeHint(tile.sizeHint())
+            tile.set_item(item)
             item.setData(Qt.UserRole, path)
             widget.addItem(item)
             widget.setItemWidget(item, tile)

--- a/pictocode/ui/project_tile.py
+++ b/pictocode/ui/project_tile.py
@@ -1,9 +1,21 @@
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QWidget,
+    QLabel,
+    QVBoxLayout,
+    QListWidgetItem,
+    QGraphicsOpacityEffect,
+)
+from PyQt5.QtGui import QIcon, QPainterPath, QRegion
+from PyQt5.QtCore import (
+    Qt,
+    QSize,
+    QPropertyAnimation,
+    QEasingCurve,
+    QRectF,
+)
 
 class ProjectTile(QWidget):
-    """Widget affichant une miniature de projet avec un overlay au survol."""
+    """Widget affichant une miniature de projet avec overlay et titre au survol."""
 
     def __init__(
         self,
@@ -16,36 +28,133 @@ class ProjectTile(QWidget):
         super().__init__(parent)
         self._width = int(width)
         self._height = int(height or width)
+        self._item: QListWidgetItem | None = None
+
+        self.setObjectName("project_tile")
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        self.title_label = QLabel(title, self)
+        self.title_label.setObjectName("tile_title")
+        self.title_label.setAlignment(Qt.AlignCenter)
+        self.title_label.hide()
+        layout.addWidget(self.title_label)
+
         self.preview = QLabel(self)
+        self.preview.setObjectName("tile_preview")
         self.preview.setFixedSize(self._width, self._height)
         self.preview.setPixmap(icon.pixmap(self._width, self._height))
         self.preview.setAlignment(Qt.AlignCenter)
         self.preview.setScaledContents(True)
         layout.addWidget(self.preview)
 
-        self.overlay = QLabel(title, self)
-        self.overlay.setAlignment(Qt.AlignCenter)
-        self.overlay.setStyleSheet(
-            "background-color: rgba(0, 0, 0, 120); color: white;"
-        )
-        self.overlay.hide()
-
-    def enterEvent(self, event):
-        self.overlay.setGeometry(0, 0, self.width(), self.height())
+        self.overlay = QLabel(self.preview)
+        self.overlay.setObjectName("tile_overlay")
+        self.overlay.setGeometry(self.preview.rect())
+        self.overlay.raise_()
         self.overlay.show()
+
+        # apply rounded clipping after overlay is created
+        self._update_clip()
+
+        self.setStyleSheet(
+            """
+            #project_tile {
+                background: #b04848;
+                border-radius: 18px;
+            }
+            QLabel#tile_preview {
+                border-radius: 18px;
+            }
+            QLabel#tile_overlay {
+                background-color: rgba(0, 0, 0, 200);
+                border-radius: 18px;
+            }
+            QLabel#tile_title {
+                color: white;
+                font-weight: bold;
+            }
+            """
+        )
+
+        # Effets d'opacite pour l'overlay et le titre
+        self.overlay_effect = QGraphicsOpacityEffect(self.overlay)
+        self.overlay.setGraphicsEffect(self.overlay_effect)
+        self.overlay_effect.setOpacity(1.0)
+
+        self.title_effect = QGraphicsOpacityEffect(self.title_label)
+        self.title_label.setGraphicsEffect(self.title_effect)
+        self.title_effect.setOpacity(0.0)
+
+        self.fade_overlay = QPropertyAnimation(self.overlay_effect, b"opacity", self)
+        self.fade_overlay.setDuration(150)
+        self.fade_overlay.setEasingCurve(QEasingCurve.OutCubic)
+
+        self.fade_title = QPropertyAnimation(self.title_effect, b"opacity", self)
+        self.fade_title.setDuration(150)
+        self.fade_title.setEasingCurve(QEasingCurve.OutCubic)
+        self.fade_title.finished.connect(self._on_title_anim_finished)
+
+    def set_item(self, item: QListWidgetItem):
+        """Assure que la taille de l'item suit celle du widget."""
+        self._item = item
+        item.setSizeHint(self.sizeHint())
+
+    # ------------------------------------------------------------------
+    # Events
+    def enterEvent(self, event):
+        self.title_label.show()
+        self.fade_title.stop()
+        self.fade_title.setStartValue(self.title_effect.opacity())
+        self.fade_title.setEndValue(1.0)
+        self.fade_title.start()
+
+        self.fade_overlay.stop()
+        self.fade_overlay.setStartValue(self.overlay_effect.opacity())
+        self.fade_overlay.setEndValue(0.0)
+        self.fade_overlay.start()
+        self._update_item_size()
         super().enterEvent(event)
 
     def leaveEvent(self, event):
-        self.overlay.hide()
+        self.fade_title.stop()
+        self.fade_title.setStartValue(self.title_effect.opacity())
+        self.fade_title.setEndValue(0.0)
+        self.fade_title.start()
+
+        self.fade_overlay.stop()
+        self.fade_overlay.setStartValue(self.overlay_effect.opacity())
+        self.fade_overlay.setEndValue(1.0)
+        self.fade_overlay.start()
         super().leaveEvent(event)
 
     def resizeEvent(self, event):
-        self.overlay.setGeometry(0, 0, self.width(), self.height())
+        self.overlay.setGeometry(self.preview.rect())
+        self._update_clip()
         super().resizeEvent(event)
 
-    def sizeHint(self):
-        return self.preview.size()
+    # ------------------------------------------------------------------
+    def sizeHint(self) -> QSize:
+        h = self._height
+        if self.title_label.isVisible():
+            h += self.title_label.sizeHint().height()
+        return QSize(self._width, h)
+
+    def _update_item_size(self):
+        if self._item is not None:
+            self._item.setSizeHint(self.sizeHint())
+
+    def _on_title_anim_finished(self):
+        if self.title_effect.opacity() == 0:
+            self.title_label.hide()
+        self._update_item_size()
+
+    def _update_clip(self):
+        path = QPainterPath()
+        rect = QRectF(self.preview.rect())
+        path.addRoundedRect(rect, 18, 18)
+        region = QRegion(path.toFillPolygon().toPolygon())
+        self.preview.setMask(region)
+        self.overlay.setMask(region)


### PR DESCRIPTION
## Summary
- display the title label using the layout so it appears above the preview
- darken the overlay and keep it clipped with rounded corners

## Testing
- `python -m compileall -q pictocode/ui`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt5.QtWidgets import QApplication
from PyQt5.QtGui import QIcon, QPixmap
from pictocode.ui.project_tile import ProjectTile
app = QApplication([])
pt = ProjectTile(QIcon(QPixmap(128,128)), 'Test', 128, 128)
pt.show()
print('sizeHint', pt.sizeHint())
app.quit()
PY`


------
https://chatgpt.com/codex/tasks/task_e_685fb6c8cd608323a2023b073461be78