### PR TITLE
Refactor project panel as tabbed interface

### DIFF
--- a/pictocode/canvas.py
+++ b/pictocode/canvas.py
@@ -1014,12 +1014,10 @@ class CanvasWidget(QGraphicsView):
             auto_show = getattr(window, "auto_show_inspector", True)
             if items:
                 window.inspector.set_target(items[0])
-                if auto_show and hasattr(window, "inspector_dock"):
-                    window.inspector_dock.setVisible(True)
+                if auto_show and hasattr(window, "tabs"):
+                    window.tabs.setCurrentWidget(window.inspector)
             else:
                 window.inspector.set_target(None)
-                if auto_show and hasattr(window, "inspector_dock"):
-                    window.inspector_dock.setVisible(False)
 
 
     def _mark_dirty(self):

--- a/pictocode/ui/windows_panel.py
+++ b/pictocode/ui/windows_panel.py
@@ -17,22 +17,28 @@ class WindowsPanel(QWidget):
             self.chk_imports,
         ):
             layout.addWidget(chk)
+        idx_props = self.main.tabs.indexOf(self.main.inspector)
         self.chk_props.stateChanged.connect(
-            lambda s: self.main.inspector_dock.setVisible(s == Qt.Checked)
+            lambda s: self.main.tabs.setTabVisible(idx_props, s == Qt.Checked)
         )
         self.chk_toolbar.stateChanged.connect(
             lambda s: self.main.toolbar.setVisible(s == Qt.Checked)
         )
+        idx_imports = self.main.tabs.indexOf(self.main.imports)
         self.chk_imports.stateChanged.connect(
-            lambda s: self.main.imports_dock.setVisible(s == Qt.Checked)
+            lambda s: self.main.tabs.setTabVisible(idx_imports, s == Qt.Checked)
         )
 
         # synchronise les cases avec l'état courant sans déclencher de signal
-        for chk, visible in (
-            (self.chk_props, self.main.inspector_dock.isVisible()),
-            (self.chk_toolbar, self.main.toolbar.isVisible()),
-            (self.chk_imports, self.main.imports_dock.isVisible()),
+        for chk, idx in (
+            (self.chk_props, idx_props),
+            (self.chk_toolbar, None),
+            (self.chk_imports, idx_imports),
         ):
             chk.blockSignals(True)
+            if idx is None:
+                visible = self.main.toolbar.isVisible()
+            else:
+                visible = self.main.tabs.tabBar().isTabVisible(idx)
             chk.setChecked(visible)
             chk.blockSignals(False)


### PR DESCRIPTION
## Summary
- switch application workspace and panels to a QTabWidget
- update canvas selection logic to open the inspector tab
- adapt windows panel to control tab visibility

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q pictocode`
- `python -m pictocode --help` *(fails: "Could not load the Qt platform plugin \"xcb\"")*

------
https://chatgpt.com/codex/tasks/task_e_685fd135a0f083238f0e5ed761abbfd6