### PR TITLE
Fix window resize cursor persisting

### DIFF
--- a/pictocode/ui/main_window.py
+++ b/pictocode/ui/main_window.py
@@ -1780,6 +1780,12 @@ class MainWindow(QMainWindow):
         self.setCursor(Qt.ArrowCursor)
         super().mouseReleaseEvent(event)
 
+    def leaveEvent(self, event):
+        """Reset cursor when leaving the window."""
+        if not self._resizing and not self._corner_dragging:
+            self.unsetCursor()
+        super().leaveEvent(event)
+
     def resizeEvent(self, event):
         super().resizeEvent(event)
 


### PR DESCRIPTION
## Summary
- ensure cursor is restored after resizing by implementing `leaveEvent`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py setup.py pictocode/*.py pictocode/ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685ff7ba8c348323b58ffe7bc3054f28