### PR TITLE
Add Blender-like tab layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ La barre de titre personnalisée prend désormais en charge le déplacement syst
 pour profiter des raccourcis de redimensionnement Windows (snap et agrandissement
 au bord de l'écran).
 
+### Disposition d'onglets inspirée de Blender
+
+L'interface peut être divisée en zones réorganisables. Chaque zone dispose d'un
+petit coin servant à la scinder horizontalement ou verticalement. Un menu
+contextuel permet également de fusionner la zone courante avec ses voisines.
+Le contenu d'une zone (éditeur, vue ou outil) se déplace simplement par
+glisser‑déposer d'une zone à l'autre. Les dispositions peuvent être sauvegardées
+au format JSON puis restaurées ultérieurement.
+
 ### Rapport de bugs
 
 En cas d'erreur inattendue, Pictocode enregistre automatiquement la trace dans `~/pictocode_logs/pictocode.log`. Ce fichier peut être joint pour signaler un problème.

--- a/pictocode/split_layout.py
+++ b/pictocode/split_layout.py
@@ -11,6 +11,8 @@ from PyQt5.QtWidgets import (
     QSplitter,
     QMenu,
     QFileDialog,
+    QDrag,
+    QMimeData,
 )
 
 
@@ -22,7 +24,17 @@ class SplitHandle(QWidget):
         self.zone = zone
         self.setFixedSize(14, 14)
         self.start = None
+        # Default cursor remains the arrow but we change it when hovering
+        self.setCursor(Qt.ArrowCursor)
+
+    def enterEvent(self, event):
+        """Show a cross cursor when hovering the handle."""
         self.setCursor(Qt.SizeAllCursor)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.setCursor(Qt.ArrowCursor)
+        super().leaveEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
@@ -47,12 +59,14 @@ class ZoneWidget(QWidget):
     """Editor zone that can be split and joined."""
 
     _id_counter = 1
-    editors = ["3D View", "Script", "Timeline", "UV/Image"]
+    editors = ["Empty", "3D View", "Script", "Timeline", "UV/Image"]
 
     def __init__(self):
         super().__init__()
         self.zone_id = ZoneWidget._id_counter
         ZoneWidget._id_counter += 1
+        self._drag_start = None
+        self.setAcceptDrops(True)
         self._build()
 
     def _build(self):
@@ -73,6 +87,44 @@ class ZoneWidget(QWidget):
         self.handle = SplitHandle(self)
         self.handle.raise_()
 
+    # ------------------------------------------------------------------
+    # Drag & drop support
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton and self.selector.geometry().contains(event.pos()):
+            self._drag_start = event.pos()
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._drag_start and (event.pos() - self._drag_start).manhattanLength() > QApplication.startDragDistance():
+            drag = QDrag(self)
+            mime = QMimeData()
+            mime.setText(self.selector.currentText())
+            drag.setMimeData(mime)
+            drag.exec_(Qt.MoveAction)
+            self._drag_start = None
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        self._drag_start = None
+        super().mouseReleaseEvent(event)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasText():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event):
+        text = event.mimeData().text()
+        if text in self.editors:
+            source = event.source()
+            self.selector.setCurrentText(text)
+            if isinstance(source, ZoneWidget) and source is not self:
+                source.selector.setCurrentIndex(0)
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
     def resizeEvent(self, event):
         self.handle.move(self.width() - self.handle.width(), 0)
         super().resizeEvent(event)
@@ -87,9 +139,21 @@ class ZoneWidget(QWidget):
     def show_context_menu(self, pos):
         menu = QMenu()
         close_act = menu.addAction("Fermer la zone")
+        join_left = menu.addAction("Fusionner \u2190")
+        join_right = menu.addAction("Fusionner \u2192")
+        join_up = menu.addAction("Fusionner \u2191")
+        join_down = menu.addAction("Fusionner \u2193")
         act = menu.exec_(pos)
         if act == close_act:
             close_zone(self)
+        elif act == join_left:
+            join_zone(self, "left")
+        elif act == join_right:
+            join_zone(self, "right")
+        elif act == join_up:
+            join_zone(self, "up")
+        elif act == join_down:
+            join_zone(self, "down")
 
 
 def split_zone(zone, orientation):
@@ -134,6 +198,28 @@ def close_zone(zone):
             lay = grand.layout()
             lay.addWidget(child)
             parent.deleteLater()
+
+
+def join_zone(zone, direction):
+    parent = zone.parent()
+    if not isinstance(parent, QSplitter):
+        return
+    idx = parent.indexOf(zone)
+    if parent.orientation() == Qt.Horizontal:
+        if direction == "left" and idx > 0:
+            to_close = parent.widget(idx - 1)
+        elif direction == "right" and idx < parent.count() - 1:
+            to_close = parent.widget(idx + 1)
+        else:
+            return
+    else:
+        if direction == "up" and idx > 0:
+            to_close = parent.widget(idx - 1)
+        elif direction == "down" and idx < parent.count() - 1:
+            to_close = parent.widget(idx + 1)
+        else:
+            return
+    close_zone(to_close)
 
 
 def serialize(widget):


### PR DESCRIPTION
## Summary
- enable drag & drop of editors between zones
- allow joining neighbouring zones via context menu
- document new layout system in the README
- change cursor to cross when hovering the tab split handle

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ffbb1ab2c83238de67233c664be44